### PR TITLE
Align the scm information in the resulting pom.xml of the maven publi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,8 @@ publishing {
                         "clusters that have AWS IAM enabled as an authentication mechanism"
                 scm {
                     url = "https://github.com/aws/aws-msk-iam-auth"
-                    connection = "https://github.com/aws/aws-msk-iam-auth.git"
+                    connection = "scm:git:https://github.com/aws/aws-msk-iam-auth.git"
+                    developerConnection = "scm:git:git@github.com:aws/aws-msk-iam-auth.git"
                 }
                 licenses {
                     license {


### PR DESCRIPTION
…cation with other aws sdks

*Description of changes:*
This change aims to modify the scm information to be similar to other aws sdks. For example the java sdk: https://github.com/aws/aws-sdk-java/blob/1c68c54f8f52fc9c7737fb68c921fa6d521a6947/pom.xml#L300

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
