### PR TITLE
Shadow jar prefix should not have - since it is not a valid java pack…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocatio
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {
     target = tasks.shadowJar
-    prefix = "aws-msk-iam-auth-shadow"
+    prefix = "aws_msk_iam_auth_shadow"
 }
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar


### PR DESCRIPTION
…age name.. Underscore is allowed based on java package name conventions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
