### PR TITLE
Add support for AWS Single Sign On based profiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation(platform('com.amazonaws:aws-java-sdk-bom:1.11.986'))
     implementation('com.amazonaws:aws-java-sdk-core')
     implementation('com.amazonaws:aws-java-sdk-sts')
+    implementation(platform('software.amazon.awssdk:bom:2.16.74'))
+    implementation('software.amazon.awssdk:auth')
+    implementation('software.amazon.awssdk:sso')
+    implementation('software.amazon.awssdk:sts')
     implementation('com.fasterxml.jackson.core:jackson-databind:2.12.2')
     implementation('org.slf4j:slf4j-api:1.7.25')
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/EnhancedProfileCredentialsProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/EnhancedProfileCredentialsProvider.java
@@ -1,0 +1,47 @@
+package software.amazon.msk.auth.iam.internals;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+/**
+ * This credential provider delegates to the v2 ProfileCredentialProvider so that users
+ * are able to use Single Sign On credentials and also get more standard credential loading
+ * behavior.
+ * See https://github.com/aws/aws-sdk-java/issues/803#issuecomment-593530484
+ */
+public class EnhancedProfileCredentialsProvider implements AWSCredentialsProvider {
+    private final ProfileCredentialsProvider delegate;
+
+    public EnhancedProfileCredentialsProvider() {
+        delegate = ProfileCredentialsProvider.create();
+    }
+
+    public EnhancedProfileCredentialsProvider(String profileName) {
+        delegate = ProfileCredentialsProvider.create(profileName);
+    }
+
+    public EnhancedProfileCredentialsProvider(ProfileFile profileFile, String profileName) {
+        delegate = ProfileCredentialsProvider.builder().profileFile(profileFile).profileName(profileName).build();
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        software.amazon.awssdk.auth.credentials.AwsCredentials credentialsV2 = delegate.resolveCredentials();
+        if (credentialsV2 instanceof AwsSessionCredentials) {
+            AwsSessionCredentials sessionCredentialsV2 = (AwsSessionCredentials) credentialsV2;
+            return new BasicSessionCredentials(sessionCredentialsV2.accessKeyId(),
+                    sessionCredentialsV2.secretAccessKey(), sessionCredentialsV2.sessionToken());
+        }
+
+        return new BasicAWSCredentials(credentialsV2.accessKeyId(), credentialsV2.secretAccessKey());
+    }
+
+    @Override
+    public void refresh() {
+    }
+}

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -18,12 +18,10 @@ package software.amazon.msk.auth.iam.internals;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -19,6 +19,10 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +52,7 @@ public class MSKCredentialProvider implements AWSCredentialsProvider {
     }
 
     MSKCredentialProvider(Map<String, ?> options,
-            Optional<ProfileCredentialsProvider> profileCredentialsProvider) {
+            Optional<EnhancedProfileCredentialsProvider> profileCredentialsProvider) {
         final List delegateList = getListOfDelegates(profileCredentialsProvider);
         delegate = new AWSCredentialsProviderChain(delegateList);
         if (log.isDebugEnabled()) {
@@ -56,19 +60,28 @@ public class MSKCredentialProvider implements AWSCredentialsProvider {
         }
     }
 
-    private List getListOfDelegates(Optional<ProfileCredentialsProvider> profileCredentialsProvider) {
+    private List getListOfDelegates(Optional<EnhancedProfileCredentialsProvider> profileCredentialsProvider) {
         final List delegateList = new ArrayList<>();
         profileCredentialsProvider.ifPresent(delegateList::add);
-        delegateList.add(new DefaultAWSCredentialsProviderChain());
+        delegateList.add(getDefaultProvider());
         return delegateList;
     }
 
-    private static Optional<ProfileCredentialsProvider> getProfileProvider(Map<String, ?> options) {
+    //We want to override the ProfileCredentialsProvider with the EnhancedProfileCredentialsProvider
+    protected AWSCredentialsProviderChain getDefaultProvider() {
+        return new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(),
+                new SystemPropertiesCredentialsProvider(),
+                WebIdentityTokenCredentialsProvider.create(),
+                new EnhancedProfileCredentialsProvider(),
+                new EC2ContainerCredentialsProviderWrapper());
+    }
+
+    private static Optional<EnhancedProfileCredentialsProvider> getProfileProvider(Map<String, ?> options) {
         return Optional.ofNullable(options.get(AWS_PROFILE_NAME_KEY)).map(p -> {
             if (log.isDebugEnabled()) {
                 log.debug("Profile name {}", p);
             }
-            return new ProfileCredentialsProvider((String) p);
+            return new EnhancedProfileCredentialsProvider((String) p);
         });
     }
 

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SystemPropertyCredentialsUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SystemPropertyCredentialsUtils.java
@@ -19,7 +19,6 @@ public final class SystemPropertyCredentialsUtils {
     private static final String ACCESS_KEY_PROPERTY = "aws.accessKeyId";
     private static final String SECRET_KEY_PROPERTY = "aws.secretKey";
     private static final String AWS_PROFILE_SYSTEM_PROPERTY = "aws.profile";
-    private static final String USER_HOME_PROPERTY = "user.home";
 
     private SystemPropertyCredentialsUtils() {
     }
@@ -47,21 +46,15 @@ public final class SystemPropertyCredentialsUtils {
     }
 
     public static void runTestWithSystemPropertyProfile(Runnable test,
-            String profileName,
-            String tempUserHome) {
+            String profileName) {
         String initialProfileName = System.getProperty(AWS_PROFILE_SYSTEM_PROPERTY);
-        String initialUserHome = System.getProperty(USER_HOME_PROPERTY);
         try {
             //Setup test system properties
             System.setProperty(AWS_PROFILE_SYSTEM_PROPERTY, profileName);
-            System.setProperty(USER_HOME_PROPERTY, tempUserHome);
             runTestWithSystemPropertyCredentials( test, "", "");
         } finally {
             if (initialProfileName != null) {
                 System.setProperty(AWS_PROFILE_SYSTEM_PROPERTY, initialProfileName);
-            }
-            if (initialUserHome != null) {
-                System.setProperty(USER_HOME_PROPERTY, initialUserHome);
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:* #16

*Description of changes:* 
This change adds support for AWS Single Sign On (AWS SSO) based config profiles. 
AWS SDK v1 does not support AWS SSO based credentials. The support for that was added only to AWS SDK v2. However, switching the whole library to use the AWS SDK v2 is a significant change. Instead I followed the suggestion in https://github.com/aws/aws-sdk-java/issues/803#issuecomment-593530484 to use the ProfileCredentialProvider from AWS SDK v2 by wrapping it in an adapter class. 

It was tested against AWS SSO.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
