### PR TITLE
Remove slf4j-api from the jars being shadowed in the uber jar so that…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ SASL mechanism can be used by Kafka clients to authenticate against Amazon MSK c
 After you've downloaded the code from GitHub, you can build it using Gradle. Use this command:
  
  `gradle clean build`
+ 
+The generated jar files can be found at: `build/libs/`.
 
-An uber jar containing the library and all its relocated dependencies can also be built. Use this command: 
+An uber jar containing the library and all its relocated dependencies except the kafka client and `slf4j-api` can
+ also be built. Use this command: 
 
 `gradle clean shadowJar` 
 
-In both cases the generated jar files can be found at: `build/libs/`
+The generated uber jar file can also be found at: `build/libs/`. At runtime, the uber jar expects to find the kafka
+ client library and the `sl4j-api` library on the classpath. 
 
 ## Using the Amazon MSK Library for IAM Authentication
 The recommended way to use this library is to consume it from maven central while building a Kafka client application.

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,13 @@ dependencies {
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
+shadowJar {
+    //We remove org.slf4j from the configuration as it gets included transitively by multiple dependencies and just
+    //removing it from the configuration being shadowed is not sufficient.
+    configurations = [project.configurations.runtimeClasspath.exclude([group: "org.slf4j", module: "slf4j-api"])]
+}
+
+
 task relocateShadowJar(type: ConfigureShadowRelocation) {
     target = tasks.shadowJar
     prefix = "aws_msk_iam_auth_shadow"


### PR DESCRIPTION
… an implementation of slf4j can be correctly loaded for logging. slf4j-api is expected to be present on the classpath along with an implementation of slf4j.

Issue #27

*Description of changes:*
Remove slf4j-api from the jars being shadowed in the uber jar so that an implementation of slf4j can be correctly loaded for logging. slf4j-api is expected to be present on the classpath along with an implementation of slf4j.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
