### PR TITLE
Relocating the aws sdk v2 packages was causing SSO to fail when using the uber-jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,16 +94,14 @@ class FilteredConfigureShadowRelocation extends ConfigureShadowRelocation {
             }
         }
         packages.each { pkg ->
-            {
-                def shouldRelocate = true
-                relocationFilterPrefix.each { prefix ->
-                    if (pkg.startsWith(prefix)) {
-                        shouldRelocate = false
-                    }
+            def shouldRelocate = true
+            relocationFilterPrefix.each { prefix ->
+                if (pkg.startsWith(prefix)) {
+                    shouldRelocate = false
                 }
-                if (shouldRelocate) {
-                    target.relocate(pkg, "${prefix}.${pkg}")
-                }
+            }
+            if (shouldRelocate) {
+                target.relocate(pkg, "${prefix}.${pkg}")
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,9 +72,48 @@ shadowJar {
 }
 
 
-task relocateShadowJar(type: ConfigureShadowRelocation) {
+import java.util.jar.JarFile
+
+class FilteredConfigureShadowRelocation extends ConfigureShadowRelocation {
+
+    @Input
+    Set<String> relocationFilterPrefix
+
+    @TaskAction
+    void configureRelocation() {
+        def packages = [] as Set<String>
+        configurations.each { configuration ->
+            configuration.files.each { jar ->
+                JarFile jf = new JarFile(jar)
+                jf.entries().each { entry ->
+                    if (entry.name.endsWith(".class")) {
+                        packages << entry.name[0..entry.name.lastIndexOf('/')-1].replaceAll('/', '.')
+                    }
+                }
+                jf.close()
+            }
+        }
+        packages.each { pkg ->
+            {
+                def shouldRelocate = true
+                relocationFilterPrefix.each { prefix ->
+                    if (pkg.startsWith(prefix)) {
+                        shouldRelocate = false
+                    }
+                }
+                if (shouldRelocate) {
+                    target.relocate(pkg, "${prefix}.${pkg}")
+                }
+            }
+        }
+
+    }
+}
+
+task relocateShadowJar(type: FilteredConfigureShadowRelocation) {
     target = tasks.shadowJar
-     prefix = "aws_msk_iam_auth_shadow"
+    prefix = "aws_msk_iam_auth_shadow"
+    relocationFilterPrefix = ["org.slf4j", "software.amazon.awssdk"]
 }
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation('com.fasterxml.jackson.core:jackson-databind:2.12.2')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
+    runtimeOnly('software.amazon.awssdk:apache-client')
+
     //test dependencies
     testImplementation('org.apache.kafka:kafka-clients:2.2.1',
             'org.junit.jupiter:junit-jupiter-api:5.7.0',
@@ -72,7 +74,7 @@ shadowJar {
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {
     target = tasks.shadowJar
-    prefix = "aws_msk_iam_auth_shadow"
+     prefix = "aws_msk_iam_auth_shadow"
 }
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar


### PR DESCRIPTION
*Issue #, if available:* #31

*Description of changes:*
Stop relocating the aws sdk v2 modules while building the uber jar so that the aws sdk v2 can find the classes it loads dynamically from the class path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
