### PR TITLE
Add retries if loading credentials fails with a SdkClientException

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ In some scenarios the IAM credentials might be transiently unavailable. This wil
 might in some cases cause the client application to stop. 
 So, in version `1.1.3` the library retries loading the credentials when it gets an `SkdClientException` (which wraps
 most `AWS SDK` client side exceptions). Since the retries do not impact the fault-free path and we had heard of user
-issues around random failures loading credentials (e.g.: https://github.com/aws/aws-msk-iam-auth/issues/59, maybe
- https://github.com/aws/aws-msk-iam-auth/issues/51 ), we decided to change the default behavior
+issues around random failures loading credentials (e.g.: [#59](https://github.com/aws/aws-msk-iam-auth/issues/59), maybe
+ [#51](https://github.com/aws/aws-msk-iam-auth/issues/51) ), we decided to change the default behavior
   to retry a maximum of `3` times. It exponentially backs off with full jitter upto a max-delay of `2000 ms`.
    
 The maximum number of retries and the maximum back off period can be set:
@@ -468,6 +468,12 @@ public static String UriEncode(CharSequence input, boolean encodeSlash) {
 ```
    
 ## Release Notes
+
+### Release 1.1.3
+
+- Add retries if loading credential fails with client side errors.
+- If AWS STS is not accessible for identifying the credential when `awsDebugCreds=true`, do not fail the connection.
+- Update Troubleshooting section in README.
 
 ### Release 1.1.2
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ The retries can be turned off completely by setting `awsMaxRetries` to `"0"`.
  
 ## Troubleshooting
 
+### IAMClientCallbackHandler could not be found
+
+A Kafka client configured to use `AWS_MSK_IAM` may see an error that the `IAMClientCallbackHandler` cannot be found:
+
+```
+Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value 
+software.amazon.msk.auth.iam.IAMClientCallbackHandler for configuration sasl.client.callback.handler.class: 
+Class software.amazon.msk.auth.iam.IAMClientCallbackHandler could not be found.
+```
+
+That means that this `aws-msk-iam-auth` library is not on the classpath of the Kafka client. Please add the `aws-msk-iam-auth` library 
+to the classpath and try again.
+
+
 ### Finding out which identity is being used
 
 You may receive an `Access denied` error and there may be some doubt as to which credential is being exactly used. The 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ For example, if the client is an EC2 instance, its instance profile should have 
 In some scenarios the IAM credentials might be transiently unavailable. This will cause the connection to fail, which
 might in some cases cause the client application to stop. 
 So, in version `1.1.3` the library retries loading the credentials when it gets an `SkdClientException` (which wraps
-most `AWS SDK` exceptions). Since the retries do not impact the fault-free path and we had heard of user issues around
-random failures loading credentials (e.g.: #59, maybe #51), we decided to change the default behavior to retry a
-mamximum of    `3` times. It exponentially backs off with full jitter upto a max-delay of `2000 ms`.
+most `AWS SDK` client side exceptions). Since the retries do not impact the fault-free path and we had heard of user
+issues around random failures loading credentials (e.g.: https://github.com/aws/aws-msk-iam-auth/issues/59, maybe
+ https://github.com/aws/aws-msk-iam-auth/issues/51 ), we decided to change the default behavior
+  to retry a maximum of `3` times. It exponentially backs off with full jitter upto a max-delay of `2000 ms`.
    
 The maximum number of retries and the maximum back off period can be set:
 ```

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -74,8 +74,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     private static final String AWS_MAX_RETRIES = "awsMaxRetries";
     private static final String AWS_MAX_BACK_OFF_TIME_MS = "awsMaxBackOffTimeMs";
     private static final int DEFAULT_MAX_RETRIES = 3;
-    private static final int DEFAULT_MAX_BACK_OFF_TIME_MS = 2000;
-    private static final int BASE_DELAY = 200;
+    private static final int DEFAULT_MAX_BACK_OFF_TIME_MS = 5000;
+    private static final int BASE_DELAY = 500;
 
     private final List<AutoCloseable> closeableProviders;
     private final AWSCredentialsProvider compositeDelegate;

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -15,6 +15,8 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
+import com.amazonaws.SdkBaseException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
@@ -23,20 +25,31 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.retry.PredefinedBackoffStrategies;
+import com.amazonaws.retry.v2.AndRetryCondition;
+import com.amazonaws.retry.v2.MaxNumberOfRetriesCondition;
+import com.amazonaws.retry.v2.RetryOnExceptionsCondition;
+import com.amazonaws.retry.v2.RetryPolicy;
+import com.amazonaws.retry.v2.RetryPolicyContext;
+import com.amazonaws.retry.v2.SimpleRetryPolicy;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
 import lombok.AccessLevel;
 import lombok.Getter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.amazonaws.util.ValidationUtils.assertNotNull;
 
 /**
  * This AWS Credential Provider is used to load up AWS Credentials based on options provided on the Jaas config line.
@@ -57,22 +70,32 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     private static final String AWS_ROLE_SESSION_KEY = "awsRoleSessionName";
     private static final String AWS_STS_REGION = "awsStsRegion";
     private static final String AWS_DEBUG_CREDS_KEY = "awsDebugCreds";
+    private static final String AWS_MAX_RETRIES = "awsMaxRetries";
+    private static final String AWS_MAX_BACK_OFF_TIME_MS = "awsMaxBackOffTimeMs";
+    private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final int DEFAULT_MAX_BACK_OFF_TIME_MS = 2000;
 
     private final List<AutoCloseable> closeableProviders;
     private final AWSCredentialsProvider compositeDelegate;
     @Getter(AccessLevel.PACKAGE)
     private final Boolean shouldDebugCreds;
     private final String stsRegion;
+    private final RetryPolicy retryPolicy;
 
     public MSKCredentialProvider(Map<String, ?> options) {
         this(new ProviderBuilder(options));
     }
 
     MSKCredentialProvider(ProviderBuilder builder) {
-        this(builder.getProviders(), builder.shouldDebugCreds(), builder.getStsRegion());
+        this(builder.getProviders(), builder.shouldDebugCreds(), builder.getStsRegion(), builder.getMaxRetries(),
+                builder.getMaxBackOffTimeMs());
     }
 
-   MSKCredentialProvider(List<AWSCredentialsProvider> providers, Boolean shouldDebugCreds, String stsRegion) {
+    MSKCredentialProvider(List<AWSCredentialsProvider> providers,
+            Boolean shouldDebugCreds,
+            String stsRegion,
+            int maxRetries,
+            int maxBackOffTimeMs) {
         List<AWSCredentialsProvider> delegateList = new ArrayList<>(providers);
         delegateList.add(getDefaultProvider());
         compositeDelegate = new AWSCredentialsProviderChain(delegateList);
@@ -80,6 +103,10 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                 .collect(Collectors.toList());
         this.shouldDebugCreds = shouldDebugCreds;
         this.stsRegion = stsRegion;
+        this.retryPolicy = new SimpleRetryPolicy(
+                new AndRetryCondition(new RetryOnExceptionsCondition(Collections.singletonList(
+                        SdkClientException.class)), new MaxNumberOfRetriesCondition(maxRetries)),
+                new PredefinedBackoffStrategies.FullJitterBackoffStrategy(200, maxBackOffTimeMs));
     }
 
     //We want to override the ProfileCredentialsProvider with the EnhancedProfileCredentialsProvider
@@ -93,11 +120,45 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
 
     @Override
     public AWSCredentials getCredentials() {
-        AWSCredentials credentials = compositeDelegate.getCredentials();
+        AWSCredentials credentials = loadCredentialsWithRetry();
         if (credentials != null && shouldDebugCreds && log.isDebugEnabled()) {
             logCallerIdentity(credentials);
         }
         return  credentials;
+    }
+
+    private AWSCredentials loadCredentialsWithRetry() {
+        RetryPolicyContext retryPolicyContext = RetryPolicyContext.builder().build();
+        boolean shouldTry = true;
+        try {
+            while (shouldTry) {
+                try {
+                    AWSCredentials credentials = compositeDelegate.getCredentials();
+                    return credentials;
+                } catch (SdkBaseException se) {
+                    log.warn("Exception loading credentials. Retry Attempts: {} Exception: {}",
+                            retryPolicyContext.retriesAttempted(), se);
+                    retryPolicyContext = createRetryPolicyContext(se, retryPolicyContext.retriesAttempted());
+                    shouldTry = retryPolicy.shouldRetry(retryPolicyContext);
+                    if (shouldTry) {
+                        Thread.sleep(retryPolicy.computeDelayBeforeNextRetry(retryPolicyContext));
+                        retryPolicyContext = createRetryPolicyContext(retryPolicyContext.exception(),
+                                retryPolicyContext.retriesAttempted() + 1);
+                    } else {
+                        throw se;
+                    }
+                }
+            }
+            return null;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for credentials.", ie);
+        }
+    }
+
+    private RetryPolicyContext createRetryPolicyContext(SdkBaseException sdkException, int retriesAttempted) {
+        return RetryPolicyContext.builder().exception(sdkException)
+                .retriesAttempted(retriesAttempted).build();
     }
 
     private void logCallerIdentity(AWSCredentials credentials) {
@@ -165,6 +226,17 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                     .orElse("aws-global");
         }
 
+        public int getMaxRetries() {
+            return Optional.ofNullable(optionsMap.get(AWS_MAX_RETRIES)).map(p -> (String) p).map(Integer::parseInt)
+                    .orElse(DEFAULT_MAX_RETRIES);
+        }
+
+        public int getMaxBackOffTimeMs() {
+            return Optional.ofNullable(optionsMap.get(AWS_MAX_BACK_OFF_TIME_MS)).map(p -> (String) p)
+                    .map(Integer::parseInt)
+                    .orElse(DEFAULT_MAX_BACK_OFF_TIME_MS);
+        }
+
         private Optional<EnhancedProfileCredentialsProvider> getProfileProvider() {
             return Optional.ofNullable(optionsMap.get(AWS_PROFILE_NAME_KEY)).map(p -> {
                 if (log.isDebugEnabled()) {
@@ -200,4 +272,5 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                     .build();
         }
     }
+
 }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -26,7 +26,6 @@ import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
-import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.v2.AndRetryCondition;
 import com.amazonaws.retry.v2.MaxNumberOfRetriesCondition;
 import com.amazonaws.retry.v2.RetryOnExceptionsCondition;
@@ -50,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.amazonaws.util.ValidationUtils.assertNotNull;
 
 /**
  * This AWS Credential Provider is used to load up AWS Credentials based on options provided on the Jaas config line.
@@ -58,9 +56,13 @@ import static com.amazonaws.util.ValidationUtils.assertNotNull;
  * sasl.jaas.config = IAMLoginModule required awsProfileName={profile name};
  * The currently supported options are:
  * 1. A particular AWS Credential profile: awsProfileName={profile name}
- * 2. A particular AWS IAM Role and optional AWS IAM role session name:
- *     awsRoleArn={IAM Role ARN}, awsRoleSessionName = {session name}
- * 3. If no options is provided, the DefaultAWSCredentialsProviderChain is used.
+ * 2. A particular AWS IAM Role and optionally AWS IAM role session name and AWS region for the STS endpoint:
+ *     awsRoleArn={IAM Role ARN}, awsRoleSessionName={session name}, awsStsRegion={region name}
+ * 3. Optional arguments to configure retries when we fail to load credentials:
+ *     awsMaxRetries={Maximum number of retries}, awsMaxBackOffTimeMs={Maximum back off time between retries in ms}
+ * 4. Optional argument to help debug credentials used to establish connections:
+ *     awsDebugCreds={true|false}
+ * 5. If no options is provided, the DefaultAWSCredentialsProviderChain is used.
  * The DefaultAWSCredentialProviderChain can be pointed to credentials in many different ways:
  * <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">Working with AWS Credentials</a>
  */

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -162,9 +162,16 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     }
 
     private void logCallerIdentity(AWSCredentials credentials) {
-        AWSSecurityTokenService stsClient = getStsClientForDebuggingCreds(credentials);
-        GetCallerIdentityResult response = stsClient.getCallerIdentity(new GetCallerIdentityRequest());
-        log.debug("The identity of the credentials is {}", response.toString());
+        try {
+            AWSSecurityTokenService stsClient = getStsClientForDebuggingCreds(credentials);
+            GetCallerIdentityResult response = stsClient.getCallerIdentity(new GetCallerIdentityRequest());
+            log.debug("The identity of the credentials is {}", response.toString());
+        } catch (Exception e) {
+            //If we run into an exception logging the caller identity, we should log the exception but
+            //continue running.
+            log.warn("Error identifying caller identity. If this is not transient, does this application have"
+                    + "access to AWS STS?", e);
+        }
     }
 
     AWSSecurityTokenService getStsClientForDebuggingCreds(AWSCredentials credentials) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
-#Updated on 2022-01-30T08:43:00Z
+#Updated on 2022-02-20T20:43:00Z
 platform=java
-version=1.1.2
+version=1.1.3-PRE

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -398,6 +398,29 @@ public class MSKCredentialProviderTest {
         Mockito.verifyNoMoreInteractions(mockEc2CredsProvider);
     }
 
+    @Test
+    public void testEc2CredsWithOnrRetriableErrorsCustomZeroRetry_ThrowsException() {
+        int numExceptions = 1;
+        Map<String, String> optionsMap = new HashMap<>();
+        optionsMap.put("awsMaxRetries", "0");
+
+        AWSCredentialsProvider mockEc2CredsProvider = setupMockDefaultProviderWithRetriableExceptions(numExceptions);
+
+        MSKCredentialProvider provider = new MSKCredentialProvider(optionsMap) {
+            protected AWSCredentialsProviderChain getDefaultProvider() {
+                return new AWSCredentialsProviderChain(mockEc2CredsProvider);
+            }
+        };
+        assertFalse(provider.getShouldDebugCreds());
+
+        assertThrows(SdkClientException.class, () -> provider.getCredentials());
+
+        Mockito.verify(mockEc2CredsProvider, times(numExceptions)).getCredentials();
+        Mockito.verifyNoMoreInteractions(mockEc2CredsProvider);
+    }
+
+
+
 
     private void testEc2CredsWithRetriableErrorsCustomRetry(int numExceptions) {
         Map<String, String> optionsMap = new HashMap<>();


### PR DESCRIPTION
*Issue #59*

*Description of changes:*
If the library fails to load credentials with a SdkClientException, we retry. The retry policy is an exponential back off policy with full jitter. By default the base retry interval is 500 ms, the max retry interval is 2000 ms and the max number of retries is 3. The max retry interval can be set via the option `awsMaxBackOffTimeMs` and the max number of retries can be set via `awsMaxRetries`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
