### PR TITLE
Adding a proxy to delegate to appropriate IAMSaslClientProvider based on ClassLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
 bin
-internals
 build
 lombok.config
+out/

--- a/src/main/java/software/amazon/msk/auth/iam/IAMLoginModule.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMLoginModule.java
@@ -15,6 +15,7 @@
 */
 package software.amazon.msk.auth.iam;
 
+import software.amazon.msk.auth.iam.internals.ClassLoaderAwareIAMSaslClientProvider;
 import software.amazon.msk.auth.iam.internals.IAMSaslClientProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ public class IAMLoginModule implements LoginModule {
     private static final Logger log = LoggerFactory.getLogger(IAMLoginModule.class);
 
     static {
+        ClassLoaderAwareIAMSaslClientProvider.initialize();
         IAMSaslClientProvider.initialize();
     }
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/ClassLoaderAwareIAMSaslClientProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/ClassLoaderAwareIAMSaslClientProvider.java
@@ -15,26 +15,22 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import software.amazon.msk.auth.iam.internals.IAMSaslClient.IAMSaslClientFactory;
+import software.amazon.msk.auth.iam.IAMLoginModule;
+import software.amazon.msk.auth.iam.internals.IAMSaslClient.ClassLoaderAwareIAMSaslClientFactory;
 
 import java.security.Provider;
 import java.security.Security;
 
-import static software.amazon.msk.auth.iam.internals.IAMSaslClient.getMechanismNameForClassLoader;
-
-public class IAMSaslClientProvider extends Provider {
+public class ClassLoaderAwareIAMSaslClientProvider extends Provider {
     /**
-     * Constructs a IAM Sasl Client provider with a fixed name, version number,
-     * and information.
+     * Constructs an IAM Sasl Client provider that installs a {@link ClassLoaderAwareIAMSaslClientFactory}.
      */
-    protected IAMSaslClientProvider() {
-        super("SASL/IAM Client Provider (" +
-                IAMSaslClientProvider.class.getClassLoader().hashCode(), 1.0,
-                ") SASL/IAM Client Provider for Kafka");
-        put("SaslClientFactory." + getMechanismNameForClassLoader(getClass().getClassLoader()), IAMSaslClientFactory.class.getName());
+    protected ClassLoaderAwareIAMSaslClientProvider() {
+        super("ClassLoader Aware SASL/IAM Client Provider", 1.0, "SASL/IAM Client Provider for Kafka");
+        put("SaslClientFactory." + IAMLoginModule.MECHANISM, ClassLoaderAwareIAMSaslClientFactory.class.getName());
     }
 
     public static void initialize() {
-        Security.addProvider(new IAMSaslClientProvider());
+        Security.addProvider(new ClassLoaderAwareIAMSaslClientProvider());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/aws/aws-msk-iam-auth/issues/36

**Description of changes:**

This change fixes the classloader issue experienced in [this issue](https://github.com/aws/aws-msk-iam-auth/issues/36). I have introduced a new `SaslClientFactory` called `ClassLoaderAwareIAMSaslClientFactory` registered under the `AWS_MSK_IAM` mechanism. The existing `IAMSaslClientFactory` has been moved to a new mechanism name `AWS_MSK_IAM.<classloader>`. Each `IAMLoginModule` will register both mechanisms, we will end up with one `ClassLoaderAwareIAMSaslClientFactory` per JVM and `n` copies of `IAMSaslClientFactory`, `n` equals the number of ClassLoaders used.

`ClassLoaderAwareIAMSaslClientFactory` picks the correct  `IAMSaslClientFactory` based on the classloader of the `CallbackHandler`

For single classloader environments, there will be 1 `ClassLoaderAwareIAMSaslClientFactory` and 1 `IAMSaslClientFactory`. We will incur a negligible performance hit delegating from one to the other.  

**Testing**

I have tested against MSK using a Flink cluster running on EC2 box. I verified this issue resolves issue #36. I am waiting for additional test feedback from other stakeholders, and am hoping that this can be verified against MSK e2e tests.

**Concerns:**

Since we register `n` copies of `IAMSaslClientFactory` there is an opportunity for this to infinitely grow and leak, for example if a Flink job is continuously failing over. However, in this situation the job is already broken and this tradeoff might be acceptable against the current state, where multi classloader environments are not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
