### PR TITLE
docs: fix minor discrepancies documenting how to generate the string to sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ From the canonical string, we derive the string that will be used to sign the au
 The String to Sign is calculated as:
 ```
 "AWS4-HMAC-SHA256" + "\n" +
-"<timestamp in yyyyMMdd format>" + "\n" +
+"<timestamp in yyyyMMddTHHmmssZ format>" + "\n" +
 <Scope> + "\n" +
 Hex(SHA256Hash(<CanonicalRequest>))
 ```
@@ -371,8 +371,8 @@ where
 * `Hex` is a function to do lowercase base 16 encoding.
 * `SHA256Hash` is a Secure Hash Algorithm (SHA) cryptographic hash function.
 
-The `<Scope>` is defined as the AWS region of the Kafka broker and the name of the service ("kafka-cluster" in this
- case). For example if the broker is in `us-west-2` region, the scope is `"us-west-2/kafka-cluster"`. It must be the same scope
+The `<Scope>` is defined as the timestamp in yyyyMMdd format, the AWS region of the Kafka broker, the name of the service ("kafka-cluster" in this
+ case), and the constant string "aws4_request". For example if the broker is in `us-west-2` region, the scope is `"<timestamp in yyyyMMdd format>/us-west-2/kafka-cluster/aws4_request"`. It must be the same scope
 as was defined for the `"X-Amz-Credential"` query parameter while generating the [canonical query string](#canonical-query-string).
 
 ### Calculate Signature


### PR DESCRIPTION
*Description of changes:*

Updates the root `README.md` file based on https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html and my recent experience implementing MSK IAM Auth in a different programming language.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
