### PR TITLE
Removing unused sts v2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation(platform('software.amazon.awssdk:bom:2.17.192'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
-    implementation('software.amazon.awssdk:sts')
     implementation('com.fasterxml.jackson.core:jackson-databind:2.13.4.2')
     implementation('org.slf4j:slf4j-api:1.7.25')
 


### PR DESCRIPTION
*Description of changes:*
The sts V2 dependency is not needed for the package. So removing it.