### PR TITLE
Add support for explicit access key and secret in sasl.jaas.config (#98)

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
  * 1. A particular AWS Credential profile: awsProfileName={profile name}
  * 2. A particular AWS IAM Role, with optional access key id an secret key, and optionally AWS IAM role session name
  *    and AWS region for the STS endpoint:
- *     awsRoleArn={IAM Role ARN}, awsAccessKeyId={access key id}, awsSecretAccessKey={secret access key},
+ *     awsRoleArn={IAM Role ARN}, awsRoleAccessKeyId={access key id}, awsSecretAccessKey={secret access key},
  *     awsRoleSessionName={session name}, awsStsRegion={region name}
  * 3. Optional arguments to configure retries when we fail to load credentials:
  *     awsMaxRetries={Maximum number of retries}, awsMaxBackOffTimeMs={Maximum back off time between retries in ms}
@@ -74,8 +74,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     private static final Logger log = LoggerFactory.getLogger(MSKCredentialProvider.class);
     private static final String AWS_PROFILE_NAME_KEY = "awsProfileName";
     private static final String AWS_ROLE_ARN_KEY = "awsRoleArn";
-    private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
-    private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAccessKey";
+    private static final String AWS_ROLE_ACCESS_KEY_ID = "awsRoleAccessKeyId";
+    private static final String AWS_ROLE_SECRET_ACCESS_KEY = "awsRoleSecretAccessKey";
     private static final String AWS_ROLE_SESSION_KEY = "awsRoleSessionName";
     private static final String AWS_STS_REGION = "awsStsRegion";
     private static final String AWS_DEBUG_CREDS_KEY = "awsDebugCreds";
@@ -286,8 +286,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                         .orElse("aws-msk-iam-auth");
                 String stsRegion = getStsRegion();
 
-                String accessKey = (String) optionsMap.getOrDefault(AWS_ACCESS_KEY_ID, null);
-                String secretKey = (String) optionsMap.getOrDefault(AWS_SECRET_ACCESS_KEY, null);
+                String accessKey = (String) optionsMap.getOrDefault(AWS_ROLE_ACCESS_KEY_ID, null);
+                String secretKey = (String) optionsMap.getOrDefault(AWS_ROLE_SECRET_ACCESS_KEY, null);
                 if (accessKey != null && secretKey != null) {
                     AWSCredentialsProvider credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
                     return createSTSRoleCredentialProvider((String) p, sessionName, stsRegion, credentials);

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -20,6 +20,8 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
@@ -56,8 +58,10 @@ import java.util.stream.Collectors;
  * sasl.jaas.config = IAMLoginModule required awsProfileName={profile name};
  * The currently supported options are:
  * 1. A particular AWS Credential profile: awsProfileName={profile name}
- * 2. A particular AWS IAM Role and optionally AWS IAM role session name and AWS region for the STS endpoint:
- *     awsRoleArn={IAM Role ARN}, awsRoleSessionName={session name}, awsStsRegion={region name}
+ * 2. A particular AWS IAM Role, with optional access key id an secret key, and optionally AWS IAM role session name
+ *    and AWS region for the STS endpoint:
+ *     awsRoleArn={IAM Role ARN}, awsAccessKeyId={access key id}, awsSecretAccessKey={secret access key},
+ *     awsRoleSessionName={session name}, awsStsRegion={region name}
  * 3. Optional arguments to configure retries when we fail to load credentials:
  *     awsMaxRetries={Maximum number of retries}, awsMaxBackOffTimeMs={Maximum back off time between retries in ms}
  * 4. Optional argument to help debug credentials used to establish connections:
@@ -70,6 +74,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     private static final Logger log = LoggerFactory.getLogger(MSKCredentialProvider.class);
     private static final String AWS_PROFILE_NAME_KEY = "awsProfileName";
     private static final String AWS_ROLE_ARN_KEY = "awsRoleArn";
+    private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAccessKey";
     private static final String AWS_ROLE_SESSION_KEY = "awsRoleSessionName";
     private static final String AWS_STS_REGION = "awsStsRegion";
     private static final String AWS_DEBUG_CREDS_KEY = "awsDebugCreds";
@@ -279,6 +285,14 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                 String sessionName = Optional.ofNullable((String) optionsMap.get(AWS_ROLE_SESSION_KEY))
                         .orElse("aws-msk-iam-auth");
                 String stsRegion = getStsRegion();
+
+                String accessKey = (String) optionsMap.getOrDefault(AWS_ACCESS_KEY_ID, null);
+                String secretKey = (String) optionsMap.getOrDefault(AWS_SECRET_ACCESS_KEY, null);
+                if (accessKey != null && secretKey != null) {
+                    AWSCredentialsProvider credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
+                    return createSTSRoleCredentialProvider((String) p, sessionName, stsRegion, credentials);
+                }
+
                 return createSTSRoleCredentialProvider((String) p, sessionName, stsRegion);
             });
         }
@@ -288,6 +302,19 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
                     .withRegion(stsRegion)
                     .build();
+            return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
+                    .withStsClient(stsClient)
+                    .build();
+        }
+
+        STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
+                                                                                String sessionName, String stsRegion,
+                                                                                AWSCredentialsProvider credentials) {
+            AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
+                    .withRegion(stsRegion)
+                    .withCredentials(credentials)
+                    .build();
+
             return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
                     .withStsClient(stsClient)
                     .build();

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -64,8 +64,8 @@ public class MSKCredentialProviderTest {
     private static final String TEST_ROLE_SESSION_NAME = "TEST_ROLE_SESSION_NAME";
     private static final String SESSION_TOKEN = "SESSION_TOKEN";
     private static final String AWS_ROLE_ARN = "awsRoleArn";
-    private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
-    private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAccessKey";
+    private static final String AWS_ROLE_ACCESS_KEY_ID = "awsRoleAccessKeyId";
+    private static final String AWS_ROLE_SECRET_ACCESS_KEY = "awsRoleSecretAccessKey";
     private static final String AWS_PROFILE_NAME = "awsProfileName";
     private static final String AWS_DEBUG_CREDS_NAME = "awsDebugCreds";
 
@@ -187,8 +187,8 @@ public class MSKCredentialProviderTest {
 
         Map<String, String> optionsMap = new HashMap<>();
         optionsMap.put(AWS_ROLE_ARN, TEST_ROLE_ARN);
-        optionsMap.put(AWS_ACCESS_KEY_ID, ACCESS_KEY_VALUE_TWO);
-        optionsMap.put(AWS_SECRET_ACCESS_KEY, SECRET_KEY_VALUE_TWO);
+        optionsMap.put(AWS_ROLE_ACCESS_KEY_ID, ACCESS_KEY_VALUE_TWO);
+        optionsMap.put(AWS_ROLE_SECRET_ACCESS_KEY, SECRET_KEY_VALUE_TWO);
 
         MSKCredentialProvider.ProviderBuilder providerBuilder = getProviderBuilderWithCredentials(mockStsRoleProvider, optionsMap,
                 "aws-msk-iam-auth");


### PR DESCRIPTION
*Issue #, if available:*
#98

*Description of changes:*
Added support for role + explicit access key/secret in the jaas config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
