### PR TITLE
Add support for session token

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -59,10 +59,10 @@ import java.util.stream.Collectors;
  * sasl.jaas.config = IAMLoginModule required awsProfileName={profile name};
  * The currently supported options are:
  * 1. A particular AWS Credential profile: awsProfileName={profile name}
- * 2. A particular AWS IAM Role, with optional access key id and secret key OR optional external id,
+ * 2. A particular AWS IAM Role, with optional access key id, secret key and session token OR optional external id,
  *    and optionally AWS IAM role session name and AWS region for the STS endpoint:
- *     awsRoleArn={IAM Role ARN}, awsRoleAccessKeyId={access key id}, awsSecretAccessKey={secret access key},
- *     awsRoleSessionName={session name}, awsStsRegion={region name}
+ *     awsRoleArn={IAM Role ARN}, awsRoleAccessKeyId={access key id}, awsRoleSecretAccessKey={secret access key},
+ *     awsRoleSessionToken={session token}, awsRoleSessionName={session name}, awsStsRegion={region name}
  * 3. Optional arguments to configure retries when we fail to load credentials:
  *     awsMaxRetries={Maximum number of retries}, awsMaxBackOffTimeMs={Maximum back off time between retries in ms}
  * 4. Optional argument to help debug credentials used to establish connections:

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -237,7 +237,7 @@ public class MSKCredentialProviderTest {
     }
 
     @Test
-    public void testEc2CredsWithDebuCredsNoAccessToSts_Succeed() {
+    public void testEc2CredsWithDebugCredsNoAccessToSts_Succeed() {
         Map<String, String> optionsMap = new HashMap<>();
         optionsMap.put(AWS_DEBUG_CREDS_NAME, "true");
 
@@ -270,7 +270,6 @@ public class MSKCredentialProviderTest {
         Mockito.verify(mockEc2CredsProvider, times(1)).getCredentials();
         Mockito.verifyNoMoreInteractions(mockEc2CredsProvider);
     }
-
 
     @Test
     public void testAwsRoleArnAndSessionName() {
@@ -377,6 +376,7 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_PROFILE_NAME, profileName);
                 return new EnhancedProfileCredentialsProvider(profileFile, TEST_PROFILE_NAME);
             }
+
             STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                                     String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
@@ -482,9 +482,6 @@ public class MSKCredentialProviderTest {
         Mockito.verifyNoMoreInteractions(mockEc2CredsProvider);
     }
 
-
-
-
     private void testEc2CredsWithRetriableErrorsCustomRetry(int numExceptions) {
         Map<String, String> optionsMap = new HashMap<>();
         optionsMap.put("awsMaxRetries", "5");
@@ -580,7 +577,6 @@ public class MSKCredentialProviderTest {
         assertEquals(SECRET_KEY_VALUE_TWO, credentials.getAWSSecretKey());
     }
 
-
     private STSAssumeRoleSessionCredentialsProvider setupMockStsRoleCredentialsProviderWithRetriableExceptions(int numErrors) {
         SdkBaseException[] exceptionsToThrow = getSdkBaseExceptions(numErrors);
 
@@ -607,7 +603,6 @@ public class MSKCredentialProviderTest {
                 .thenReturn(new BasicAWSCredentials(ACCESS_KEY_VALUE_TWO, SECRET_KEY_VALUE_TWO));
         return mockEc2Provider;
     }
-
 
     private ProfileFile getProfileFile() {
         return ProfileFile.builder().content(new File(getProfileResourceURL().getFile()).toPath()).type(


### PR DESCRIPTION
This PR adds support to pass session credentials to an STS role credential provider in addition to static AWS credentials. This allows to receive temporary credentials using STS and then pass them along. This can be useful in [role-chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining) scenarios, where the MSKCredentialProvider is known to be used for a short amount of time only.

## Background

In [Imply Polaris](https://imply.io/imply-polaris/), we provide users with the ability to set up authentication to their MSK clusters using a user-provided ARN of an IAM role. Before starting ingestion from that MSK cluster to Druid, we want to give users the ability to "test" their connection and credentials. To do so, we create a short-lived [KafkaConsumer](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java) which we pass a set of client configuration values (as outlined in this project).

Due to our security architecture, we don't want the service running the above logic to be able to assume arbitrary roles. Instead, the service will first assume another role (in fact, the role that the Druid cluster uses), and only then assumes the user-provided role. To do this role-chaining, we need to be able to pass the short-lived session credentials we received from assuming the initial role to the MSKCredentialProvider.

The complete flow would then be as follows:

1. Use STS client to assume role A, get temporary credentials
2. Create a KafkaConsumer with configuration properties including a SASL config containing those temporary credentials. For example, if the `credentials` come from `stsClient.assumeRole(roleRequest).getCredentials()`, pseudo-code for setting the SASL config could look like this:

    ```ini
    sasl.jaas.config = software.amazon.msk.auth.iam.IAMLoginModule required \
        awsRoleArn="customer-arn" \
        awsRoleAccessKeyId="credentials.getAccessKeyId()" \
        awsRoleSecretAccessKey="credentials.getSecretAccessKey()" \
        awsRoleSessionToken="credentials.getSessionToken()"
    ```

Resolves #111

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
