### PR TITLE
Add support for STS Regional Endpoint (#118)

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -28,7 +28,6 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
 import com.amazonaws.retry.v2.AndRetryCondition;
@@ -272,7 +271,7 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
         public EndpointConfiguration buildEndpointConfiguration(String stsRegion){
             //An AWSSecurityTokenService with a regional endpoint configuration
             EndpointConfiguration endpointConfiguration =
-                    new AwsClientBuilder.EndpointConfiguration(
+                    new EndpointConfiguration(
                             String.format("sts.%s.amazonaws.com", stsRegion),
                             stsRegion);
             //An AWSSecurityTokenService with a global endpoint configuration

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -108,10 +108,10 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
     }
 
     MSKCredentialProvider(List<AWSCredentialsProvider> providers,
-                          Boolean shouldDebugCreds,
-                          String stsRegion,
-                          int maxRetries,
-                          int maxBackOffTimeMs) {
+            Boolean shouldDebugCreds,
+            String stsRegion,
+            int maxRetries,
+            int maxBackOffTimeMs) {
         List<AWSCredentialsProvider> delegateList = new ArrayList<>(providers);
         delegateList.add(getDefaultProvider());
         compositeDelegate = new AWSCredentialsProviderChain(delegateList);
@@ -202,19 +202,19 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
 
     AWSSecurityTokenService getStsClientForDebuggingCreds(AWSCredentials credentials) {
         return AWSSecurityTokenServiceClientBuilder.standard()
-                .withRegion(stsRegion)
-                .withCredentials(new AWSCredentialsProvider() {
-                    @Override
-                    public AWSCredentials getCredentials() {
-                        return credentials;
-                    }
+            .withRegion(stsRegion)
+            .withCredentials(new AWSCredentialsProvider() {
+                @Override
+                public AWSCredentials getCredentials() {
+                    return credentials;
+                }
 
-                    @Override
-                    public void refresh() {
+                @Override
+                public void refresh() {
 
-                    }
-                })
-                .build();
+                }
+            })
+            .build();
     }
 
     @Override

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -28,6 +28,8 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
 import com.amazonaws.retry.v2.AndRetryCondition;
 import com.amazonaws.retry.v2.MaxNumberOfRetriesCondition;
@@ -267,6 +269,22 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                     .orElse(DEFAULT_MAX_BACK_OFF_TIME_MS);
         }
 
+        public EndpointConfiguration buildEndpointConfiguration(String stsRegion){
+            //An AWSSecurityTokenService with a regional endpoint configuration
+            EndpointConfiguration endpointConfiguration =
+                    new AwsClientBuilder.EndpointConfiguration(
+                            String.format("sts.%s.amazonaws.com", stsRegion),
+                            stsRegion);
+            //An AWSSecurityTokenService with a global endpoint configuration
+            if (stsRegion.equals("aws-global")) {
+                endpointConfiguration =
+                        new EndpointConfiguration(
+                                "sts.amazonaws.com",
+                                stsRegion);
+            }
+            return endpointConfiguration;
+        }
+
         private Optional<EnhancedProfileCredentialsProvider> getProfileProvider() {
             return Optional.ofNullable(optionsMap.get(AWS_PROFILE_NAME_KEY)).map(p -> {
                 if (log.isDebugEnabled()) {
@@ -311,8 +329,9 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
 
         STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                                 String sessionName, String stsRegion) {
+            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withRegion(stsRegion)
+                    .withEndpointConfiguration(endpointConfiguration)
                     .build();
             return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
                     .withStsClient(stsClient)
@@ -322,8 +341,9 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
         STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                                 String sessionName, String stsRegion,
                                                                                 AWSCredentialsProvider credentials) {
+            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withRegion(stsRegion)
+                    .withEndpointConfiguration(endpointConfiguration)
                     .withCredentials(credentials)
                     .build();
 
@@ -336,8 +356,10 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                                                                                 String externalId,
                                                                                 String sessionName,
                                                                                 String stsRegion) {
+
+            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withRegion(stsRegion)
+                    .withEndpointConfiguration(endpointConfiguration)
                     .build();
 
             return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -312,6 +314,9 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
+
                 return mockStsRoleProvider;
             }
         };
@@ -347,6 +352,9 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_EXTERNAL_ID, externalId);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
+
                 return mockStsRoleProvider;
             }
         };
@@ -381,6 +389,8 @@ public class MSKCredentialProviderTest {
                                                                                     String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals("aws-msk-iam-auth", sessionName);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -537,6 +547,8 @@ public class MSKCredentialProviderTest {
                     String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -550,6 +562,8 @@ public class MSKCredentialProviderTest {
                     AWSCredentialsProvider credentials) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };


### PR DESCRIPTION
*Issue #, if available:*
This PR fixed the issue #118 

Users who are using the library in a VPC with no Internet connection are not able to use the Assume role feature as STS Regional End point doesn't work.

*Description of changes:*
This PR add an STS Endpoint configuration in the Credential Provider to enable the usage of region STS Endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
