### PR TITLE
#127 add awsRegion to jaas configurations

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/IAMClientCallbackHandler.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMClientCallbackHandler.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(IAMClientCallbackHandler.class);
     private AWSCredentialsProvider provider;
+    private String awsRegion;
 
     @Override
     public void configure(Map<String, ?> configs,
@@ -53,6 +54,8 @@ public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
                 .filter(j -> IAMLoginModule.class.getCanonicalName().equals(j.getLoginModuleName())).findFirst();
         provider = configEntry.map(c -> (AWSCredentialsProvider) new MSKCredentialProvider(c.getOptions()))
                 .orElse(DefaultAWSCredentialsProviderChain.getInstance());
+        awsRegion = configEntry.map(c -> (String) c.getOptions().getOrDefault(MSKCredentialProvider.AWS_REGION, null))
+                .orElse(null);
     }
 
     @Override
@@ -98,6 +101,7 @@ public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
         try {
             provider.refresh();
             callback.setAwsCredentials(provider.getCredentials());
+            callback.setAWSRegion(awsRegion);
         } catch (Exception e) {
             callback.setLoadingException(e);
         }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWSCredentialsCallback.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWSCredentialsCallback.java
@@ -33,10 +33,16 @@ public class AWSCredentialsCallback implements Callback {
     private AWSCredentials awsCredentials = null;
     @Getter
     private Exception loadingException = null;
+    @Getter
+    private String awsRegion = null;
 
     public void setAwsCredentials(@NonNull AWSCredentials awsCredentials) {
         this.awsCredentials = awsCredentials;
         this.loadingException = null;
+    }
+
+    public void setAWSRegion(String awsRegion) {
+        this.awsRegion = awsRegion;
     }
 
     public void setLoadingException(@NonNull Exception loadingException) {

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
@@ -57,9 +57,14 @@ class AuthenticationRequestParams {
 
     public static AuthenticationRequestParams create(@NonNull String host,
             AWSCredentials credentials,
-            @NonNull String userAgent) throws IllegalArgumentException {
-        Region region = Optional.ofNullable(regionMetadata.tryGetRegionByEndpointDnsSuffix(host))
-                .orElseGet(() -> Regions.getCurrentRegion());
+            @NonNull String userAgent, String awsRegion) throws IllegalArgumentException {
+        Region region;
+        if(awsRegion != null) { // override region if specified
+            region = Region.getRegion(Regions.fromName(awsRegion));
+        } else {
+            region = Optional.ofNullable(regionMetadata.tryGetRegionByEndpointDnsSuffix(host))
+                    .orElseGet(() -> Regions.getCurrentRegion());
+        }
         if (region == null) {
             throw new IllegalArgumentException("Host " + host + " does not belong to a valid region.");
         }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
@@ -239,8 +239,6 @@ public class IAMSaslClient implements SaslClient {
                 CallbackHandler cbh) throws SaslException {
             String mechanismName = getMechanismNameForClassLoader(getClass().getClassLoader());
 
-            System.out.println(props);
-
             for (String mechanism : mechanisms) {
                 if (mechanismName.equals(mechanism)) {
                     return new IAMSaslClient(mechanism, cbh, serverName, new AWS4SignedPayloadGenerator());

--- a/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
@@ -141,7 +141,8 @@ public class IAMSaslClient implements SaslClient {
             //Generate the signed payload
             final byte[] response = payloadGenerator.signedPayload(
                     AuthenticationRequestParams
-                            .create(serverName, callback.getAwsCredentials(), UserAgentUtils.getUserAgentValue()));
+                            .create(serverName, callback.getAwsCredentials(), UserAgentUtils.getUserAgentValue(),
+                                    callback.getAwsRegion()));
             //transition to the state waiting to receive server response.
             setState(State.RECEIVE_SERVER_RESPONSE);
             return response;
@@ -237,6 +238,8 @@ public class IAMSaslClient implements SaslClient {
                 Map<String, ?> props,
                 CallbackHandler cbh) throws SaslException {
             String mechanismName = getMechanismNameForClassLoader(getClass().getClassLoader());
+
+            System.out.println(props);
 
             for (String mechanism : mechanisms) {
                 if (mechanismName.equals(mechanism)) {

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -75,6 +75,7 @@ import java.util.stream.Collectors;
  * <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">Working with AWS Credentials</a>
  */
 public class MSKCredentialProvider implements AWSCredentialsProvider, AutoCloseable {
+    public static final String AWS_REGION = "awsRegion";
     private static final Logger log = LoggerFactory.getLogger(MSKCredentialProvider.class);
     private static final String AWS_PROFILE_NAME_KEY = "awsProfileName";
     private static final String AWS_ROLE_ARN_KEY = "awsRoleArn";

--- a/src/test/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGeneratorTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGeneratorTest.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
 
 public class AWS4SignedPayloadGeneratorTest {
     private static final String VALID_HOSTNAME = "b-3.unit-test.abcdef.kafka.us-west-2.amazonaws.com";
+    private static final String HOST_REGION = "us-west-2";
     private static final String ACCESS_KEY = "ACCESS_KEY";
     private static final String SECRET_KEY = "SECRET_KEY";
     private static final String USER_AGENT = "USER_AGENT";
@@ -41,7 +42,7 @@ public class AWS4SignedPayloadGeneratorTest {
     @Test
     public void testSigning() throws IOException, ParseException {
         AuthenticationRequestParams params = AuthenticationRequestParams
-                .create(VALID_HOSTNAME, credentials, UserAgentUtils.getUserAgentValue());
+                .create(VALID_HOSTNAME, credentials, UserAgentUtils.getUserAgentValue(), HOST_REGION);
         AWS4SignedPayloadGenerator generator = new AWS4SignedPayloadGenerator();
         byte[] signedPayload = generator.signedPayload(params);
 

--- a/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
@@ -42,9 +42,22 @@ public class AuthenticateRequestParamsTest {
     }
 
     @Test
-    public void testAllProperties() {
+    public void testSpecifiedRegion() {
         AuthenticationRequestParams params = AuthenticationRequestParams
-                .create(VALID_HOSTNAME, credentials, USER_AGENT);
+                .create(VALID_HOSTNAME, credentials, USER_AGENT, "us-east-2");
+
+        assertEquals("us-east-2", params.getRegion().getName());
+        assertEquals("kafka-cluster", params.getServiceScope());
+        assertEquals(USER_AGENT, params.getUserAgent());
+        assertEquals(VALID_HOSTNAME, params.getHost());
+        assertEquals(ACCESS_KEY, params.getAwsCredentials().getAWSAccessKeyId());
+        assertEquals(SECRET_KEY, params.getAwsCredentials().getAWSSecretKey());
+    }
+
+    @Test
+    public void testUnspecifiedRegion() {
+        AuthenticationRequestParams params = AuthenticationRequestParams
+                .create(VALID_HOSTNAME, credentials, USER_AGENT, null);
 
         assertEquals("us-west-2", params.getRegion().getName());
         assertEquals("kafka-cluster", params.getServiceScope());
@@ -59,7 +72,7 @@ public class AuthenticateRequestParamsTest {
         try (MockedStatic<Regions> regionsMockedStatic = Mockito.mockStatic(Regions.class)) {
             regionsMockedStatic.when(Regions::getCurrentRegion).thenReturn(null);
             assertThrows(IllegalArgumentException.class,
-                    () -> AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT));
+                    () -> AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT, null));
         }
     }
 
@@ -67,7 +80,7 @@ public class AuthenticateRequestParamsTest {
     public void testInvalidHostInEC2() {
         try (MockedStatic<Regions> regionsMockedStatic = Mockito.mockStatic(Regions.class)) {
             regionsMockedStatic.when(Regions::getCurrentRegion).thenReturn(TEST_EC2_REGION);
-            AuthenticationRequestParams params = AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT);
+            AuthenticationRequestParams params = AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT, null);
             assertEquals(TEST_EC2_REGION, params.getRegion());
         }
     }

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
@@ -82,6 +82,7 @@ public final class SignedPayloadValidatorUtils {
         String[] credentialArray = credential.split("/");
         assertEquals(5, credentialArray.length);
         assertEquals(params.getAwsCredentials().getAWSAccessKeyId(), credentialArray[0]);
+        assertEquals(params.getRegion().getName(), credentialArray[2]);
         String userAgent = propertyMap.get("user-agent");
         assertNotNull(userAgent);
         assertTrue(userAgent.startsWith("aws-msk-iam-auth"));


### PR DESCRIPTION
*Issue #, if available:*
fixes #127 Auth failure when connecting from cross-region to MSK and cross-cloud

*Description of changes:*
Add a new jass-config field awsRegion, set this in the callback, and then read it from the IAM Sasl Client to set the aws region when creating the signature

For testing, I have validated these with the unit tests and by creating a custom jar, then confirming that it solves the issue described in the issue