### PR TITLE
#127 Change region metadata provider to use partitions loader

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
@@ -39,6 +39,8 @@ class AuthenticationRequestParams {
     private static final String VERSION_1 = "2020_10_22";
     private static final String SERVICE_SCOPE = "kafka-cluster";
     private static RegionMetadata regionMetadata = new RegionMetadata(new PartitionsLoader().build());
+    /* we are not using the RegionMetadataFactory.create() method here as one of its path
+    relies on the LegacyRegionXmlMetadataBuilder which does not implement tryGetRegionByEndpointDnsSuffix */
 
     @NonNull
     private final String version;

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
@@ -18,7 +18,7 @@ package software.amazon.msk.auth.iam.internals;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionMetadata;
-import com.amazonaws.regions.RegionMetadataFactory;
+import com.amazonaws.partitions.PartitionsLoader;
 import com.amazonaws.regions.Regions;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -38,7 +38,7 @@ import java.util.Optional;
 class AuthenticationRequestParams {
     private static final String VERSION_1 = "2020_10_22";
     private static final String SERVICE_SCOPE = "kafka-cluster";
-    private static RegionMetadata regionMetadata = RegionMetadataFactory.create();
+    private static RegionMetadata regionMetadata = new RegionMetadata(new PartitionsLoader().build());
 
     @NonNull
     private final String version;


### PR DESCRIPTION
*Issue #, if available:*
Described in #127 Auth failure when connecting from cross-region to MSK and cross-cloud

*Description of changes:*
The LegacyRegionXmlMetadataBuilder is built on the [InMemoryRegionsProvider](https://github.com/aws/aws-sdk-java/blob/6d566c7972ba70945b33ab95fcfb5b10a77c93f0/aws-java-sdk-core/src/main/java/com/amazonaws/regions/InMemoryRegionsProvider.java#L76) which does not implement the `tryGetRegionByEndpointDnsSuffix` method. This changes the call to `RegionMetadataFactory.create()` to PartitionsLoader instead which does define that method.