### PR TITLE
Revert commits for STS regional endpoint

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -28,9 +28,6 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
 import com.amazonaws.retry.v2.AndRetryCondition;
 import com.amazonaws.retry.v2.MaxNumberOfRetriesCondition;
@@ -202,19 +199,19 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
 
     AWSSecurityTokenService getStsClientForDebuggingCreds(AWSCredentials credentials) {
         return AWSSecurityTokenServiceClientBuilder.standard()
-            .withRegion(stsRegion)
-            .withCredentials(new AWSCredentialsProvider() {
-                @Override
-                public AWSCredentials getCredentials() {
-                    return credentials;
-                }
+                    .withRegion(stsRegion)
+                    .withCredentials(new AWSCredentialsProvider() {
+                        @Override
+                        public AWSCredentials getCredentials() {
+                            return credentials;
+                        }
 
-                @Override
-                public void refresh() {
+                        @Override
+                        public void refresh() {
 
-                }
-            })
-            .build();
+                        }
+                    })
+                    .build();
     }
 
     @Override
@@ -270,17 +267,6 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                     .orElse(DEFAULT_MAX_BACK_OFF_TIME_MS);
         }
 
-        public EndpointConfiguration buildEndpointConfiguration(String stsRegion){
-            Region region = RegionUtils.getRegion(stsRegion);
-            String serviceEndpoint = region.getServiceEndpoint("sts");
-            EndpointConfiguration endpointConfiguration =
-                    new EndpointConfiguration(
-                            String.format(serviceEndpoint, stsRegion),
-                            stsRegion);
-
-            return endpointConfiguration;
-        }
-
         private Optional<EnhancedProfileCredentialsProvider> getProfileProvider() {
             return Optional.ofNullable(optionsMap.get(AWS_PROFILE_NAME_KEY)).map(p -> {
                 if (log.isDebugEnabled()) {
@@ -325,9 +311,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
 
         STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                                 String sessionName, String stsRegion) {
-            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withEndpointConfiguration(endpointConfiguration)
+                    .withRegion(stsRegion)
                     .build();
             return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
                     .withStsClient(stsClient)
@@ -337,9 +322,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
         STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                                 String sessionName, String stsRegion,
                                                                                 AWSCredentialsProvider credentials) {
-            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withEndpointConfiguration(endpointConfiguration)
+                    .withRegion(stsRegion)
                     .withCredentials(credentials)
                     .build();
 
@@ -352,10 +336,8 @@ public class MSKCredentialProvider implements AWSCredentialsProvider, AutoClosea
                                                                                 String externalId,
                                                                                 String sessionName,
                                                                                 String stsRegion) {
-
-            EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
             AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withEndpointConfiguration(endpointConfiguration)
+                    .withRegion(stsRegion)
                     .build();
 
             return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import com.amazonaws.client.builder.AwsClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -314,9 +312,6 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
-                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
-                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
-
                 return mockStsRoleProvider;
             }
         };
@@ -352,9 +347,6 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_EXTERNAL_ID, externalId);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
-                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
-                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
-
                 return mockStsRoleProvider;
             }
         };
@@ -389,8 +381,6 @@ public class MSKCredentialProviderTest {
                                                                                     String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals("aws-msk-iam-auth", sessionName);
-                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
-                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -547,8 +537,6 @@ public class MSKCredentialProviderTest {
                     String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
-                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
-                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -562,8 +550,6 @@ public class MSKCredentialProviderTest {
                     AWSCredentialsProvider credentials) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
-                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
-                assertEquals("sts.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };


### PR DESCRIPTION
We are reverting the commits as we are seeing the following issue where passing only `awsRoleArn` to Jaas config without using an overrided `awsStsRegion`.
```
An error: (java.security.PrivilegedActionException: javax.security.sasl.SaslException: Failed to find AWS IAM Credentials [Caused by aws_msk_iam_auth_shadow.com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException: Credential should be scoped to a valid region. (Service: AWSSecurityTokenService; Status Code: 403; Error Code: SignatureDoesNotMatch; Request ID: 14905a5d-2bf2-4ff1-976a-c7d7ca5b9a02; Proxy: null)]) occurred when evaluating SASL token received from the Kafka Broker. Kafka Client will go to AUTHENTICATION_FAILED state.) (org.apache.kafka.common.network.Selector)
```

- Revert "Remove formatting" This reverts commit 45be4a59cd0784754cab14a1a2b4e40314b1588f.
- Revert "use API to get ServiceEndpoint" This reverts commit e68c800529273ab63a89d98d659955aca8c85e8c.
- Revert "add tests & remove unnesseray import" This reverts commit 8f735c07ab5c60cb15eecfb07292547fbc7e94ce.
- Revert "Update MSKCredentialProvider.java" This reverts commit 34d68b263394e915fcb9acb26ff5e90e207627d2.
- Revert "Add support for STS Regional Endpoint (#118)" This reverts commit ed0027f31e2008ac09798bbba9ae98eb56c676cc.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
