### PR TITLE
 Allow users to pass awsAccessKeyId awsSecretAccessKey. They can spec…

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/AwsBasicCredentialsProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AwsBasicCredentialsProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.msk.auth.iam.internals;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.util.StringUtils;
+
+/**
+ * {@link AWSCredentialsProvider} implementation that provides credentials by
+ * looking at the <code>aws.accessKeyId</code> and <code>aws.secretKey</code>
+ * Java system properties.
+ */
+public class AwsBasicCredentialsProvider implements AWSCredentialsProvider {
+
+    private final String accessKeyId;
+    private final String secretAccessKey;
+
+    public AwsBasicCredentialsProvider(String accessKeyId, String secretAccessKey) {
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        if (StringUtils.isNullOrEmpty(this.accessKeyId) || StringUtils.isNullOrEmpty(this.secretAccessKey)) {
+            throw new SdkClientException("Unable to get AWS credentials");
+        }
+        return new BasicAWSCredentials(this.accessKeyId, this.secretAccessKey);
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/test/java/software/amazon/msk/auth/iam/AdminClientTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/AdminClientTest.java
@@ -1,0 +1,38 @@
+package software.amazon.msk.auth.iam;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+public class AdminClientTest {
+    private static final String SASL_IAM_JAAS_CONFIG_VALUE = "software.amazon.msk.auth.iam.IAMLoginModule required awsAccessKeyId=\"\" awsSecretAccessKey=\"\";";
+
+    @Test
+//    @Tag("ignored")
+    public void testListTopics() {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "localhost:9092");
+        properties.put("sasl.jaas.config", SASL_IAM_JAAS_CONFIG_VALUE);
+        properties.put("security.protocol", "SASL_SSL");
+        properties.put("sasl.mechanism", "AWS_MSK_IAM");
+        properties.put("sasl.client.callback.handler.class", "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+
+        AdminClient adminClient = AdminClient.create(properties);
+
+        try {
+            Collection<TopicListing> topicListingCollection = adminClient.listTopics().listings().get();
+            Assertions.assertTrue( 0<  topicListingCollection.size(), "not found topics");
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
 Allow users to pass awsAccessKeyId awsSecretAccessKey. They can specify awsAccessKeyId=access-key-id  awsSecretAccessKey=secret-access-key as an option on the sasl.jaas.config

add AwsBasicCredentialsProvider.java 
and add `MSKCredentialProvider.ProviderBuilder.getAwsBasicCredentialProvider()` method to MSKCredentialProvider.java



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
