### PR TITLE
Enabling STS regional endpoint to be used by specifying STS region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The recommended way to use this library is to consume it from maven central whil
   <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
   </dependency>
   ```
 If you want to use it with a pre-existing Kafka client, you could build the uber jar and place it in the Kafka client's
@@ -518,6 +518,9 @@ public static String UriEncode(CharSequence input, boolean encodeSlash) {
 ```
    
 ## Release Notes
+
+### Release 2.0.1
+- Enable STS region support to set regional endpoints
 
 ### Release 2.0.0
 - Add SASL/OAUTHBEARER mechanism with IAM

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
-#Updated on 2023-11-08T16:12:00Z
+#Updated on 2023-12-04T11:23:00Z
 platform=java
-version=2.0.0
+version=2.0.1

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -312,6 +314,8 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -347,6 +351,8 @@ public class MSKCredentialProviderTest {
                 assertEquals(TEST_ROLE_EXTERNAL_ID, externalId);
                 assertEquals(TEST_ROLE_SESSION_NAME, sessionName);
                 assertEquals("eu-west-1", stsRegion);
+                AwsClientBuilder.EndpointConfiguration endpointConfiguration = buildEndpointConfiguration(stsRegion);
+                assertEquals("sts.eu-west-1.amazonaws.com", endpointConfiguration.getServiceEndpoint());
                 return mockStsRoleProvider;
             }
         };
@@ -531,10 +537,10 @@ public class MSKCredentialProviderTest {
     }
 
     private MSKCredentialProvider.ProviderBuilder getProviderBuilder(STSAssumeRoleSessionCredentialsProvider mockStsRoleProvider,
-            Map<String, String> optionsMap, String s) {
+                                                                     Map<String, String> optionsMap, String s) {
         return new MSKCredentialProvider.ProviderBuilder(optionsMap) {
             STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
-                    String sessionName, String stsRegion) {
+                                                                                    String sessionName, String stsRegion) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
                 return mockStsRoleProvider;
@@ -543,11 +549,11 @@ public class MSKCredentialProviderTest {
     }
 
     private MSKCredentialProvider.ProviderBuilder getProviderBuilderWithCredentials(STSAssumeRoleSessionCredentialsProvider mockStsRoleProvider,
-            Map<String, String> optionsMap, String s) {
+                                                                                    Map<String, String> optionsMap, String s) {
         return new MSKCredentialProvider.ProviderBuilder(optionsMap) {
             STSAssumeRoleSessionCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
-                    String sessionName, String stsRegion,
-                    AWSCredentialsProvider credentials) {
+                                                                                    String sessionName, String stsRegion,
+                                                                                    AWSCredentialsProvider credentials) {
                 assertEquals(TEST_ROLE_ARN, roleArn);
                 assertEquals(s, sessionName);
                 return mockStsRoleProvider;


### PR DESCRIPTION
* https://github.com/aws/aws-msk-iam-auth/issues/118

* Brought in original changes. Added an if condition to only add endpoint if region is set. Otherwise to use global region, and thus, global endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
