### PR TITLE
Add refreshing of credentials before Oauth token generation

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandler.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandler.java
@@ -136,6 +136,7 @@ public class IAMOAuthBearerLoginCallbackHandler implements AuthenticateCallbackH
         if (callback.token() != null) {
             throw new IllegalArgumentException("Callback had a token already");
         }
+        credentialsProvider.refresh();
         AWSCredentials awsCredentials = credentialsProvider.getCredentials();
 
         // Generate token value i.e. Base64 encoded pre-signed URL string


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-msk-iam-auth/issues/143. 

*Description of changes:*

We'll refresh IAM credentials before every token generation to address race conditions between the token generator thread and re-authentication workflow of the connection. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
