### PR TITLE
Fix SSO OIDC error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation(platform('software.amazon.awssdk:bom:2.20.121'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
+    implementation("software.amazon.awssdk:ssooidc")
     implementation('software.amazon.awssdk:sts')
     implementation('com.fasterxml.jackson.core:jackson-databind:2.14.1')
     implementation('org.slf4j:slf4j-api:1.7.25')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: This fix this error `To use SSO OIDC related properties in the 'non-prod-base' profile, the 'ssooidc' service module must be on the class path.`
My company using SSO on AWS. The default SSO role is only have assume role permission. So I have to assume role to my team's role (Role chaining). But I have this error.
After add `ssooidc` and build a new jar. That fixed the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
