### PR TITLE
Reverting change to jackson databind as it broke shadowJar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation('software.amazon.awssdk:sso')
     implementation("software.amazon.awssdk:ssooidc")
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.17.0')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.14.1')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     runtimeOnly('software.amazon.awssdk:apache-client')


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* ShadowJar was broken because of the update to databind. Reverting it for now so we can release other changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
