### PR TITLE
feat: replace request and signer api v1 to v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     // aws sdk imports.
     implementation(platform('com.amazonaws:aws-java-sdk-bom:1.12.638'))
     implementation('com.amazonaws:aws-java-sdk-core')
-    implementation('com.amazonaws:aws-java-sdk-sts')
     implementation(platform('software.amazon.awssdk:bom:2.23.3'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')

--- a/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
+++ b/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
@@ -13,15 +13,4 @@ public class CompatibilityHelper {
   public static Region toV2Region(com.amazonaws.regions.Region region) {
     return Region.of(region.getName());
   }
-
-  /**
-   * Convert region from v2 to v1
-   *
-   * @param region v2 region
-   * @return v1 region
-   */
-  public static com.amazonaws.regions.Region toV1Region(Region region) {
-    return com.amazonaws.regions.Region.getRegion(
-        com.amazonaws.regions.Regions.fromName(region.id()));
-  }
 }

--- a/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
+++ b/src/main/java/software/amazon/msk/auth/iam/CompatibilityHelper.java
@@ -1,33 +1,27 @@
 package software.amazon.msk.auth.iam;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
 
 public class CompatibilityHelper {
 
   /**
-   * Convert credentials from v2 to v1
+   * Convert region from v1 to v2
    *
-   * @param newCreadientials v2 credentials
-   * @return v1 credentials
+   * @param region v1 region
+   * @return v2 region
    */
-  public static AWSCredentials toV1Credentials(AwsCredentials newCreadientials) {
-    if (newCreadientials instanceof AwsSessionCredentials) {
-      return new BasicSessionCredentials(
-          newCreadientials.accessKeyId(),
-          newCreadientials.secretAccessKey(),
-          ((AwsSessionCredentials) newCreadientials).sessionToken()
-      );
-    } else {
-      return new BasicAWSCredentials(
-          newCreadientials.accessKeyId(),
-          newCreadientials.secretAccessKey()
-      );
-    }
+  public static Region toV2Region(com.amazonaws.regions.Region region) {
+    return Region.of(region.getName());
+  }
+
+  /**
+   * Convert region from v2 to v1
+   *
+   * @param region v2 region
+   * @return v1 region
+   */
+  public static com.amazonaws.regions.Region toV1Region(Region region) {
+    return com.amazonaws.regions.Region.getRegion(
+        com.amazonaws.regions.Regions.fromName(region.id()));
   }
 }

--- a/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerToken.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerToken.java
@@ -32,8 +32,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 
-import com.amazonaws.auth.internal.SignerConstants;
-
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
 import software.amazon.awssdk.utils.StringUtils;
 
 /**
@@ -65,9 +64,9 @@ public class IAMOAuthBearerToken implements OAuthBearerToken {
         List<NameValuePair> params = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
         Map<String, String> paramMap = params.stream()
                 .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
-        int lifeTimeSeconds = Integer.parseInt(paramMap.get(SignerConstants.X_AMZ_EXPIRES));
+        int lifeTimeSeconds = Integer.parseInt(paramMap.get(SignerConstant.X_AMZ_EXPIRES));
         final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
-        final LocalDateTime signedDate = LocalDateTime.parse(paramMap.get(SignerConstants.X_AMZ_DATE), dateFormat);
+        final LocalDateTime signedDate = LocalDateTime.parse(paramMap.get(SignerConstant.X_AMZ_DATE), dateFormat);
         long signedDateEpochMillis = signedDate.toInstant(ZoneOffset.UTC)
                 .toEpochMilli();
         this.startTimeMs = signedDateEpochMillis;

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
@@ -22,23 +22,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.sql.Date;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.msk.auth.iam.CompatibilityHelper;
 
 /**
  * This class is used to generate the AWS Sigv4 signed authentication payload sent by the IAMSaslClient to the broker.

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
@@ -15,11 +15,8 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.amazonaws.DefaultRequest;
-import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.internal.SignerConstants;
-import com.amazonaws.http.HttpMethodName;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.temporal.ChronoUnit;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +32,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.msk.auth.iam.CompatibilityHelper;
 
 /**
@@ -52,11 +55,12 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
     private static final String ACTION_VALUE = "kafka-cluster:Connect";
     private static final String VERSION_KEY = "version";
     private static final String USER_AGENT_KEY = "user-agent";
+    private static final String PROTOCOL = "https";
     private static final int EXPIRY_DURATION_MINUTES = 15;
 
     @Override
     public byte[] signedPayload(@NonNull AuthenticationRequestParams params) throws PayloadGenerationException {
-        final DefaultRequest request = presignRequest(params);
+        final SdkHttpFullRequest request = presignRequest(params);
 
         try {
             return toPayloadBytes(request, params);
@@ -69,45 +73,38 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
      * Presigns the request with AWS sigv4
      *
      * @param params authentication request parameters
-     * @return DefaultRequest object
+     * @return presigned request
      */
-    public DefaultRequest presignRequest(@NonNull AuthenticationRequestParams params) {
-        final AWS4Signer signer = getConfiguredSigner(params);
-        final DefaultRequest request = createRequestForSigning(params);
+    public SdkHttpFullRequest presignRequest(@NonNull AuthenticationRequestParams params) {
+        SdkHttpFullRequest request = createRequestForSigning(params);
+        Aws4PresignerParams signingParams = createSigningParams(params);
 
-        signer.presignRequest(request, CompatibilityHelper.toV1Credentials(params.getAwsCredentials()), getExpiryDate());
-        return request;
+        return Aws4Signer.create().presign(request, signingParams);
     }
 
-    private DefaultRequest createRequestForSigning(AuthenticationRequestParams params) {
-        final DefaultRequest request = new DefaultRequest(params.getServiceScope());
-        request.setHttpMethod(HttpMethodName.GET);
-        try {
-            request.setEndpoint(new URI("kafka://" + params.getHost()));
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Failed to parse host URI", e);
-        }
-        request.addParameter(ACTION_KEY, ACTION_VALUE);
-        return request;
+    private SdkHttpFullRequest createRequestForSigning(AuthenticationRequestParams params) {
+        return SdkHttpFullRequest.builder()
+            .method(SdkHttpMethod.GET)
+            .protocol(PROTOCOL)
+            .host(params.getHost())
+            .appendRawQueryParameter(ACTION_KEY, ACTION_VALUE)
+            .build();
     }
 
-    private java.util.Date getExpiryDate() {
-        return Date.from(Instant.ofEpochMilli(Instant.now().toEpochMilli() + TimeUnit.MINUTES.toMillis(
-                EXPIRY_DURATION_MINUTES)));
+    private Aws4PresignerParams createSigningParams(AuthenticationRequestParams params) {
+        return Aws4PresignerParams.builder()
+            .awsCredentials(params.getAwsCredentials())
+            .expirationTime(getExpiry())
+            .signingRegion(params.getRegion())
+            .signingName(params.getServiceScope())
+            .build();
     }
 
-    private AWS4Signer getConfiguredSigner(AuthenticationRequestParams params) {
-        final AWS4Signer aws4Signer = new AWS4Signer();
-        aws4Signer.setServiceName(params.getServiceScope());
-        aws4Signer.setRegionName(params.getRegion().getName());
-        if (log.isDebugEnabled()) {
-            log.debug("Signer configured for {} service and {} region", aws4Signer.getServiceName(),
-                    aws4Signer.getRegionName());
-        }
-        return aws4Signer;
+    private Instant getExpiry() {
+        return Instant.now().plus(EXPIRY_DURATION_MINUTES, ChronoUnit.MINUTES);
     }
 
-    private byte[] toPayloadBytes(DefaultRequest request, AuthenticationRequestParams params) throws IOException {
+    private byte[] toPayloadBytes(SdkHttpFullRequest request, AuthenticationRequestParams params) throws IOException {
         final Map<String, String> keyValueMap = toKeyValueMap(request, params);
 
         final ObjectMapper mapper = new ObjectMapper();
@@ -123,11 +120,11 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
      * @param params  The authentication request parameters used to generate the signed request.
      * @return A key value map containing the query parameters and headers from the signed request.
      */
-    private Map<String, String> toKeyValueMap(DefaultRequest request,
+    private Map<String, String> toKeyValueMap(SdkHttpFullRequest request,
             AuthenticationRequestParams params) {
         final Map<String, String> keyValueMap = new HashMap<>();
 
-        final Set<Map.Entry<String, List<String>>> parameterEntries = request.getParameters().entrySet();
+        final Set<Map.Entry<String, List<String>>> parameterEntries = request.rawQueryParameters().entrySet();
         parameterEntries.stream().forEach(
                 e -> keyValueMap.put(e.getKey().toLowerCase(), generateParameterValue(e.getKey(), e.getValue())));
 
@@ -135,8 +132,9 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
         keyValueMap.put(USER_AGENT_KEY, params.getUserAgent());
 
         //Add the headers.
-        final Set<Map.Entry<String, String>> headerEntries = request.getHeaders().entrySet();
-        headerEntries.stream().forEach(e -> keyValueMap.put(e.getKey().toLowerCase(), e.getValue()));
+        final Set<Map.Entry<String, List<String>>> headerEntries = request.headers().entrySet();
+        headerEntries.stream()
+            .forEach(e -> keyValueMap.put(e.getKey().toLowerCase(), e.getValue().get(0)));
 
         return keyValueMap;
     }
@@ -157,7 +155,7 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
             return "";
         }
         if (value.size() > 1) {
-            if (!SignerConstants.X_AMZ_SIGNED_HEADER.equals(key)) {
+            if (!SignerConstant.X_AMZ_SIGNED_HEADERS.equals(key)) {
                 throw new IllegalArgumentException(
                         "Unexpected number of arguments " + value.size() + " for query parameter " + key);
             }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
@@ -15,7 +15,8 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.amazonaws.regions.Region;
+import static software.amazon.msk.auth.iam.CompatibilityHelper.toV2Region;
+
 import com.amazonaws.regions.RegionMetadata;
 import com.amazonaws.partitions.PartitionsLoader;
 import com.amazonaws.regions.Regions;
@@ -26,6 +27,7 @@ import lombok.NonNull;
 
 import java.util.Optional;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
 
 /**
  * This class represents the parameters that will be used to generate the Sigv4 signature
@@ -60,11 +62,11 @@ public class AuthenticationRequestParams {
     public static AuthenticationRequestParams create(@NonNull String host,
             AwsCredentials credentials,
             @NonNull String userAgent) throws IllegalArgumentException {
-        Region region = Optional.ofNullable(regionMetadata.tryGetRegionByEndpointDnsSuffix(host))
+        com.amazonaws.regions.Region region = Optional.ofNullable(regionMetadata.tryGetRegionByEndpointDnsSuffix(host))
                 .orElseGet(() -> Regions.getCurrentRegion());
         if (region == null) {
             throw new IllegalArgumentException("Host " + host + " does not belong to a valid region.");
         }
-        return new AuthenticationRequestParams(VERSION_1, host, credentials, region, userAgent);
+        return new AuthenticationRequestParams(VERSION_1, host, credentials, toV2Region(region), userAgent);
     }
 }

--- a/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
@@ -40,8 +40,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import com.amazonaws.auth.internal.SignerConstants;
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -196,21 +195,21 @@ public class IAMOAuthBearerLoginCallbackHandlerTest {
         Map<String, String> paramMap = params.stream()
                 .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
         Assertions.assertEquals("kafka-cluster:Connect", paramMap.get("Action"));
-        Assertions.assertEquals(SignerConstants.AWS4_SIGNING_ALGORITHM, paramMap.get(SignerConstants.X_AMZ_ALGORITHM));
-        final Integer expirySeconds = Integer.parseInt(paramMap.get(SignerConstants.X_AMZ_EXPIRES));
+        Assertions.assertEquals(SignerConstant.AWS4_SIGNING_ALGORITHM, paramMap.get(SignerConstant.X_AMZ_ALGORITHM));
+        final Integer expirySeconds = Integer.parseInt(paramMap.get(SignerConstant.X_AMZ_EXPIRES));
         Assertions.assertTrue(expirySeconds <= 900);
-        Assertions.assertTrue(token.lifetimeMs() <= System.currentTimeMillis() + Integer.parseInt(paramMap.get(SignerConstants.X_AMZ_EXPIRES)) * 1000);
-        Assertions.assertEquals(sessionToken, paramMap.get(SignerConstants.X_AMZ_SECURITY_TOKEN));
-        Assertions.assertEquals("host", paramMap.get(SignerConstants.X_AMZ_SIGNED_HEADER));
-        String credential = paramMap.get(SignerConstants.X_AMZ_CREDENTIAL);
+        Assertions.assertTrue(token.lifetimeMs() <= System.currentTimeMillis() + Integer.parseInt(paramMap.get(SignerConstant.X_AMZ_EXPIRES)) * 1000);
+        Assertions.assertEquals(sessionToken, paramMap.get(SignerConstant.X_AMZ_SECURITY_TOKEN));
+        Assertions.assertEquals("host", paramMap.get(SignerConstant.X_AMZ_SIGNED_HEADERS));
+        String credential = paramMap.get(SignerConstant.X_AMZ_CREDENTIAL);
         Assertions.assertNotNull(credential);
         String[] credentialArray = credential.split("/");
         Assertions.assertEquals(5, credentialArray.length);
         Assertions.assertEquals(accessKey, credentialArray[0]);
         Assertions.assertEquals("kafka-cluster", credentialArray[3]);
-        Assertions.assertEquals(SignerConstants.AWS4_TERMINATOR, credentialArray[4]);
+        Assertions.assertEquals(SignerConstant.AWS4_TERMINATOR, credentialArray[4]);
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
-        final LocalDateTime signedDate = LocalDateTime.parse(paramMap.get(SignerConstants.X_AMZ_DATE), dateFormat);
+        final LocalDateTime signedDate = LocalDateTime.parse(paramMap.get(SignerConstant.X_AMZ_DATE), dateFormat);
         long signedDateEpochMillis = signedDate.toInstant(ZoneOffset.UTC)
                 .toEpochMilli();
         Assertions.assertTrue(signedDateEpochMillis <= Instant.now()

--- a/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
@@ -15,7 +15,7 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.amazonaws.regions.Region;
+import software.amazon.awssdk.regions.Region;
 import com.amazonaws.regions.Regions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static software.amazon.msk.auth.iam.CompatibilityHelper.toV1Region;
 
 public class AuthenticateRequestParamsTest {
     private static final String VALID_HOSTNAME = "b-3.unit-test.abcdef.kafka.us-west-2.amazonaws.com";
@@ -34,7 +35,7 @@ public class AuthenticateRequestParamsTest {
     private static final String ACCESS_KEY = "ACCESS_KEY";
     private static final String SECRET_KEY = "SECRET_KEY";
     private static final String USER_AGENT = "USER_AGENT";
-    private static final Region TEST_EC2_REGION = Region.getRegion(Regions.US_WEST_1);
+    private static final Region TEST_EC2_REGION = Region.US_WEST_1;
 
     @BeforeEach
     public void setup() {
@@ -46,7 +47,7 @@ public class AuthenticateRequestParamsTest {
         AuthenticationRequestParams params = AuthenticationRequestParams
                 .create(VALID_HOSTNAME, credentials, USER_AGENT);
 
-        assertEquals("us-west-2", params.getRegion().getName());
+        assertEquals("us-west-2", params.getRegion().id());
         assertEquals("kafka-cluster", params.getServiceScope());
         assertEquals(USER_AGENT, params.getUserAgent());
         assertEquals(VALID_HOSTNAME, params.getHost());
@@ -66,9 +67,10 @@ public class AuthenticateRequestParamsTest {
     @Test
     public void testInvalidHostInEC2() {
         try (MockedStatic<Regions> regionsMockedStatic = Mockito.mockStatic(Regions.class)) {
-            regionsMockedStatic.when(Regions::getCurrentRegion).thenReturn(TEST_EC2_REGION);
+            regionsMockedStatic.when(Regions::getCurrentRegion)
+                .thenReturn(com.amazonaws.regions.Region.getRegion(Regions.US_WEST_1));
             AuthenticationRequestParams params = AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT);
-            assertEquals(TEST_EC2_REGION, params.getRegion());
+            assertEquals(Region.US_WEST_1, params.getRegion());
         }
     }
 

--- a/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static software.amazon.msk.auth.iam.CompatibilityHelper.toV1Region;
 
 public class AuthenticateRequestParamsTest {
     private static final String VALID_HOSTNAME = "b-3.unit-test.abcdef.kafka.us-west-2.amazonaws.com";

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
@@ -15,7 +15,6 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.amazonaws.auth.internal.SignerConstants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -27,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,12 +37,12 @@ public final class SignedPayloadValidatorUtils {
     private static final String HOST = "host";
     private static final String[] requiredKeys = {VERSION,
             HOST,
-            SignerConstants.X_AMZ_CREDENTIAL.toLowerCase(),
-            SignerConstants.X_AMZ_DATE.toLowerCase(),
-            SignerConstants.X_AMZ_SIGNED_HEADER.toLowerCase(),
-            SignerConstants.X_AMZ_EXPIRES.toLowerCase(),
-            SignerConstants.X_AMZ_SIGNATURE.toLowerCase(),
-            SignerConstants.X_AMZ_ALGORITHM.toLowerCase()};
+            SignerConstant.X_AMZ_CREDENTIAL.toLowerCase(),
+            SignerConstant.X_AMZ_DATE.toLowerCase(),
+            SignerConstant.X_AMZ_SIGNED_HEADERS.toLowerCase(),
+            SignerConstant.X_AMZ_EXPIRES.toLowerCase(),
+            SignerConstant.X_AMZ_SIGNATURE.toLowerCase(),
+            SignerConstant.X_AMZ_ALGORITHM.toLowerCase()};
 
     private static final String ACTION = "action";
     private static final String[] optionalKeys = {
@@ -71,13 +71,13 @@ public final class SignedPayloadValidatorUtils {
         assertEquals("2020_10_22", propertyMap.get(VERSION));
         assertEquals(params.getHost(), propertyMap.get(HOST));
         assertEquals("kafka-cluster:Connect", propertyMap.get(ACTION));
-        assertEquals("host", propertyMap.get(SignerConstants.X_AMZ_SIGNED_HEADER.toLowerCase()));
-        assertEquals(SignerConstants.AWS4_SIGNING_ALGORITHM,
-                propertyMap.get(SignerConstants.X_AMZ_ALGORITHM.toLowerCase()));
-        assertTrue(dateFormat.parse(propertyMap.get(SignerConstants.X_AMZ_DATE.toLowerCase())).toInstant()
+        assertEquals("host", propertyMap.get(SignerConstant.X_AMZ_SIGNED_HEADERS.toLowerCase()));
+        assertEquals(SignerConstant.AWS4_SIGNING_ALGORITHM,
+                propertyMap.get(SignerConstant.X_AMZ_ALGORITHM.toLowerCase()));
+        assertTrue(dateFormat.parse(propertyMap.get(SignerConstant.X_AMZ_DATE.toLowerCase())).toInstant()
                 .isBefore(Instant.now()));
-        assertTrue(Integer.parseInt(propertyMap.get(SignerConstants.X_AMZ_EXPIRES.toLowerCase())) <= 900);
-        String credential = propertyMap.get(SignerConstants.X_AMZ_CREDENTIAL.toLowerCase());
+        assertTrue(Integer.parseInt(propertyMap.get(SignerConstant.X_AMZ_EXPIRES.toLowerCase())) <= 900);
+        String credential = propertyMap.get(SignerConstant.X_AMZ_CREDENTIAL.toLowerCase());
         assertNotNull(credential);
         String[] credentialArray = credential.split("/");
         assertEquals(5, credentialArray.length);


### PR DESCRIPTION
*Description of changes:*

Replacing (mainly):
* `com.amazonaws.DefaultRequest` to `software.amazon.awssdk.http.SdkHttpFullRequest`
* `com.amazonaws.auth.AWS4Signer` to `software.amazon.awssdk.auth.signer.Aws4Signer`
* Remove sts v1 dependency

Remaining V1 imports (I do not find a good equivalent for now):
* com.amazonaws.regions.RegionMetadata
* com.amazonaws.partitions.PartitionsLoader
* com.amazonaws.regions.Regions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
