### PR TITLE
Changing ProfileCredentialProvider to use Default file supplier to refresh credentials

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -52,6 +52,7 @@ import software.amazon.awssdk.core.retry.conditions.MaxNumberOfRetriesCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
@@ -314,7 +315,10 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         }
 
         ProfileCredentialsProvider createEnhancedProfileCredentialsProvider(String p) {
-            return ProfileCredentialsProvider.create(p);
+            return ProfileCredentialsProvider.builder()
+                    .profileName(p)
+                    .profileFile(ProfileFileSupplier.defaultSupplier())
+                    .build();
         }
 
         private Optional<StsAssumeRoleCredentialsProvider> getStsRoleProvider() {


### PR DESCRIPTION
When updating to AWS SDK v2, the default profile credential reloader doesn't refresh credentials.

https://github.com/aws/aws-sdk-java-v2/issues/1754

Fixes that problem:

*Issue #, if available:*

https://github.com/aws/aws-msk-iam-auth/issues/176

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
