### PR TITLE
Bugfix: Allowing async credential refresh for STS role credentials

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -166,8 +166,9 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
 
     @Override
     public AwsCredentials resolveCredentials() {
+        log.error("RESOLVING CREDENTIALS!!");
         AwsCredentials credentials = loadCredentialsWithRetry();
-        if (credentials != null && shouldDebugCreds && log.isDebugEnabled()) {
+        if (credentials != null && shouldDebugCreds) {
             logCallerIdentity(credentials);
         }
         return  credentials;
@@ -218,7 +219,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         try {
             StsClient stsClient = getStsClientForDebuggingCreds(credentials);
             GetCallerIdentityResponse response = stsClient.getCallerIdentity();
-            log.debug("The identity of the credentials is {}", response.toString());
+            log.error("The identity of the credentials is {}", response.toString());
         } catch (Exception e) {
             //If we run into an exception logging the caller identity, we should log the exception but
             //continue running.
@@ -362,6 +363,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
                 .refreshRequest(roleRequest)
+                .asyncCredentialUpdateEnabled(true)
                 .build();
         }
 
@@ -379,6 +381,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
                 .refreshRequest(roleRequest)
+                .asyncCredentialUpdateEnabled(true)
                 .build();
         }
 
@@ -395,6 +398,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(getStsClientBuilder(Region.of(stsRegion)).build())
                 .refreshRequest(roleRequest)
+                .asyncCredentialUpdateEnabled(true)
                 .build();
         }
     }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -166,9 +166,8 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
 
     @Override
     public AwsCredentials resolveCredentials() {
-        log.error("RESOLVING CREDENTIALS!!");
         AwsCredentials credentials = loadCredentialsWithRetry();
-        if (credentials != null && shouldDebugCreds) {
+        if (credentials != null && shouldDebugCreds && log.isDebugEnabled()) {
             logCallerIdentity(credentials);
         }
         return  credentials;
@@ -219,7 +218,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         try {
             StsClient stsClient = getStsClientForDebuggingCreds(credentials);
             GetCallerIdentityResponse response = stsClient.getCallerIdentity();
-            log.error("The identity of the credentials is {}", response.toString());
+            log.debug("The identity of the credentials is {}", response.toString());
         } catch (Exception e) {
             //If we run into an exception logging the caller identity, we should log the exception but
             //continue running.
@@ -362,7 +361,6 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
-                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();
@@ -381,7 +379,6 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
-                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();
@@ -399,7 +396,6 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(getStsClientBuilder(Region.of(stsRegion)).build())
-                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -362,6 +362,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
+                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();
@@ -380,6 +381,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(stsClient)
+                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();
@@ -397,6 +399,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                 .build();
             return StsAssumeRoleCredentialsProvider.builder()
                 .stsClient(getStsClientBuilder(Region.of(stsRegion)).build())
+                .asyncCredentialUpdateEnabled(true)
                 .refreshRequest(roleRequest)
                 .asyncCredentialUpdateEnabled(true)
                 .build();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-msk-iam-auth/issues/180

*Description of changes:*

Allowing async credential refresh to prevent reauthentication failures when `awsRoleArn` is used.
