### PR TITLE
Enables default credential providers to asynchronously refresh credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ For more details on SASL/OAUTHBEARER mechanism, please read - [KIP-255](https://
 security.protocol=SASL_SSL
 # Identifies the SASL mechanism to use.
 sasl.mechanism=OAUTHBEARER
-# Binds SASL client implementation.
+# Binds SASL client implementation. You can add client credential configurations here.
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
 # Encapsulates constructing a SigV4 signature based on extracted credentials.
 # The SASL client bound by "sasl.jaas.config" invokes this class.
 sasl.login.callback.handler.class=software.amazon.msk.auth.iam.IAMOAuthBearerLoginCallbackHandler
+# This is used during client authentication and reauthentication
+sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMOAuthBearerLoginCallbackHandler
 ```
 
 This configuration finds IAM credentials using the [AWS Default Credentials Provider Chain][DefaultCreds]. To summarize,

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -15,20 +15,10 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import java.net.URI;
-import java.time.Duration;
-import java.util.concurrent.ExecutionException;
 import lombok.AccessLevel;
 import lombok.Getter;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -51,7 +41,6 @@ import software.amazon.awssdk.core.retry.conditions.AndRetryCondition;
 import software.amazon.awssdk.core.retry.conditions.MaxNumberOfRetriesCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
-import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -62,10 +51,19 @@ import software.amazon.awssdk.services.sts.endpoints.StsEndpointProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
 
 /**
  * This AWS Credential Provider is used to load up AWS Credentials based on options provided on the Jaas config line.
- * As as an example
+ * As an example
  * sasl.jaas.config = IAMLoginModule required awsProfileName={profile name};
  * The currently supported options are:
  * 1. A particular AWS Credential profile: awsProfileName={profile name}
@@ -157,10 +155,10 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         return AwsCredentialsProviderChain.of(
             EnvironmentVariableCredentialsProvider.create(),
             SystemPropertyCredentialsProvider.create(),
-            WebIdentityTokenFileCredentialsProvider.create(),
-            ProfileCredentialsProvider.create(),
-            ContainerCredentialsProvider.builder().build(),
-            InstanceProfileCredentialsProvider.create()
+            WebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build(),
+            ProfileCredentialsProvider.builder().profileFile(ProfileFileSupplier.defaultSupplier()).build(),
+            ContainerCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build(),
+            InstanceProfileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-msk-iam-auth/issues/180

*Description of changes:*

1. Enables default credential providers to asynchronously refresh credentials.
2. Updates README to allow OAUTHBEARER re-authentication to work. This is just a documentation problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
