### PR TITLE
Update dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,27 +39,27 @@ version = readVersion()
 group "software.amazon.msk"
 
 dependencies {
-    compileOnly('org.apache.kafka:kafka-clients:2.8.1')
+    compileOnly('org.apache.kafka:kafka-clients:2.8.2')
     // aws sdk imports.
-    implementation(platform('software.amazon.awssdk:bom:2.26.8'))
+    implementation(platform('software.amazon.awssdk:bom:2.29.12'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.14.1')
-    implementation('org.slf4j:slf4j-api:1.7.25')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.18.1')
+    implementation('org.slf4j:slf4j-api:1.7.36')
 
     runtimeOnly('software.amazon.awssdk:apache-client')
 
     //test dependencies
-    testImplementation('org.apache.kafka:kafka-clients:2.2.1')
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.0')
-    testImplementation('org.apache.commons:commons-lang3:3.11')
-    testImplementation('org.mockito:mockito-inline:3.6.0')
+    testImplementation('org.apache.kafka:kafka-clients:2.8.2')
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.11.3')
+    testImplementation('org.apache.commons:commons-lang3:3.17.0')
+    testImplementation('org.mockito:mockito-inline:3.12.4')
 
-    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.0')
-    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.17.1')
-    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.17.1')
+    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.11.3')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.24.1')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.24.1')
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation


### PR DESCRIPTION
[Issue #193](https://github.com/aws/aws-msk-iam-auth/issues/193)

Bumping versions of project dependencies (minors only), including `software.amazon.awssdk:bom`, which includes vulnerable netty client.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
