### PR TITLE
allow setting role session name for WebIdentityTokenFileCredentialsProvider

### DIFF
--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -155,7 +155,6 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         return AwsCredentialsProviderChain.of(
             EnvironmentVariableCredentialsProvider.create(),
             SystemPropertyCredentialsProvider.create(),
-            WebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build(),
             ProfileCredentialsProvider.builder().profileFile(ProfileFileSupplier.defaultSupplier()).build(),
             ContainerCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build(),
             InstanceProfileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build()
@@ -257,6 +256,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
             List<AwsCredentialsProvider> providers = new ArrayList<>();
             getProfileProvider().ifPresent(providers::add);
             getStsRoleProvider().ifPresent(providers::add);
+            providers.add(getWebIdentityTokenProvider());
             return providers;
         }
 
@@ -345,6 +345,14 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
 
                 return createSTSRoleCredentialProvider((String) p, sessionName, stsRegion);
             });
+        }
+
+        private WebIdentityTokenFileCredentialsProvider getWebIdentityTokenProvider() {
+            Optional<String> sessionName = Optional.ofNullable((String) optionsMap.get(AWS_ROLE_SESSION_KEY));
+            if (sessionName.isPresent()) {
+                return WebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).roleSessionName(sessionName.get()).build();
+            }
+            return WebIdentityTokenFileCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build();
         }
 
         StsAssumeRoleCredentialsProvider createSTSRoleCredentialProvider(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `WebIdentityTokenFileCredentialsProvider` allows to set a custom session role name. I want to use the MSK quota so I want my authenticated users to have a stable arn rather than a SDK generated one. 
This change allows us to set a stable role session name for this credential provider. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
