### PR TITLE
Bump software.amazon.awssdk:bom to 2.30.23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ group "software.amazon.msk"
 dependencies {
     compileOnly('org.apache.kafka:kafka-clients:2.8.1')
     // aws sdk imports.
-    implementation(platform('software.amazon.awssdk:bom:2.26.8'))
+    implementation(platform('software.amazon.awssdk:bom:2.30.23'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')


### PR DESCRIPTION
Bump `software.amazon.awssdk:bom` to `2.30.23`. Tested pre-release jar with change by producing and consuming with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.