### PR TITLE
Bump com.fasterxml.jackson.core:jackson-databind to 2.18.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.14.1')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.18.3')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     runtimeOnly('software.amazon.awssdk:apache-client')
@@ -68,6 +68,7 @@ shadowJar {
     //We remove org.slf4j from the configuration as it gets included transitively by multiple dependencies and just
     //removing it from the configuration being shadowed is not sufficient.
     configurations = [project.configurations.runtimeClasspath.exclude([group: "org.slf4j", module: "slf4j-api"])]
+    exclude 'META-INF/versions/17/', 'META-INF/versions/21/', 'META-INF/versions/22/'
 }
 
 


### PR DESCRIPTION
Bump `com.fasterxml.jackson.core:jackson-databind` to `2.18.3`.

Fixes #198 