### PR TITLE
update aws sdk version and signed constant import

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ group "software.amazon.msk"
 dependencies {
     compileOnly('org.apache.kafka:kafka-clients:2.8.1')
     // aws sdk imports.
-    implementation(platform('software.amazon.awssdk:bom:2.36.3'))
+    implementation(platform('software.amazon.awssdk:bom:2.38.3'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')

--- a/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerToken.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerToken.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.msk.auth.iam.internals.utils.URIUtils;
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 
 /**
  * This class is used to generate the AWS Sigv4 signed authentication payload sent by the IAMSaslClient to the broker.

--- a/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
@@ -37,7 +37,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 import software.amazon.msk.auth.iam.internals.utils.URIUtils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Update AWS SDK version to `2.38.3` to use newest location of `SignerConstant.java` in `http-auth-aws` module: https://github.com/aws/aws-sdk-java-v2/blob/master/core/http-auth-aws/src/main/java/software/amazon/awssdk/http/auth/aws/signer/SignerConstant.java
- Updated imports of `SignerConstant` to new location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
