### PR TITLE
Upgrade jackson-databind from 2.18.3 to Jackson 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The recommended way to use this library is to consume it from maven central whil
   <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>
-      <version>2.3.5</version>
+      <version>2.4.0</version>
   </dependency>
   ```
 If you want to use it with a pre-existing Kafka client, you could build the uber jar and place it in the Kafka client's
@@ -566,6 +566,9 @@ public static String UriEncode(CharSequence input, boolean encodeSlash) {
 ```
    
 ## Release Notes
+
+### Release 2.4.0
+- Upgrade Jackson Databind from 2.18.3 to Jackson 3.1.0
 
 ### Release 2.3.5
 - Upgrade AWS SDK version to address CVE-2025-58056 and CVE-2025-58057

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.18.3')
+    implementation('tools.jackson.core:jackson-databind:3.1.0')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     runtimeOnly('software.amazon.awssdk:apache-client')
@@ -73,6 +73,7 @@ shadowJar {
     configurations = [project.configurations.runtimeClasspath.exclude([group: "org.slf4j", module: "slf4j-api"])]
     exclude 'META-INF/versions/17/', 'META-INF/versions/21/', 'META-INF/versions/22/'
 
+    relocate 'tools.jackson', 'aws_msk_iam_auth_shadow.tools.jackson'
     relocate 'com.fasterxml.jackson', 'aws_msk_iam_auth_shadow.com.fasterxml.jackson'
     relocate 'com.h2database', 'aws_msk_iam_auth_shadow.com.h2database'
 }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWS4SignedPayloadGenerator.java
@@ -15,11 +15,12 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.temporal.ChronoUnit;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -101,7 +102,7 @@ public class AWS4SignedPayloadGenerator implements SignedPayloadGenerator {
     private byte[] toPayloadBytes(SdkHttpFullRequest request, AuthenticationRequestParams params) throws IOException {
         final Map<String, String> keyValueMap = toKeyValueMap(request, params);
 
-        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectMapper mapper = JsonMapper.builder().build();
         return mapper.writeValueAsBytes(keyValueMap);
     }
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
@@ -17,11 +17,13 @@ package software.amazon.msk.auth.iam.internals;
 
 import software.amazon.msk.auth.iam.IAMClientCallbackHandler;
 import software.amazon.msk.auth.iam.IAMLoginModule;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import org.apache.kafka.common.errors.IllegalSaslStateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -109,7 +111,7 @@ public class IAMSaslClient implements SaslClient {
         } catch (SaslException se) {
             setState(State.FAILED);
             throw se;
-        } catch (IOException | IllegalArgumentException | UnsupportedCallbackException e) {
+        } catch (IOException | IllegalArgumentException | UnsupportedCallbackException | JacksonException e) {
             setState(State.FAILED);
             throw new SaslException("Exception while evaluating challenge", e);
         } finally {
@@ -122,7 +124,7 @@ public class IAMSaslClient implements SaslClient {
     private void handleServerResponse(byte[] challenge) throws IOException {
         //If we got a non-empty server challenge, then the authentication succeeded on the server.
         //Deserialize and log the server response as necessary.
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonMapper.builder().build();
         AuthenticationResponse response = mapper.readValue(challenge, AuthenticationResponse.class);
         if (response == null) {
             throw new SaslException("Invalid response from server ");

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 #Updated on 2025-10-29T16:45:00Z
 platform=java
-version=2.3.5
+version=2.4.0

--- a/src/test/java/software/amazon/msk/auth/iam/internals/IAMSaslClientTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/IAMSaslClientTest.java
@@ -18,12 +18,13 @@ package software.amazon.msk.auth.iam.internals;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.msk.auth.iam.IAMClientCallbackHandler;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.common.errors.IllegalSaslStateException;
 import org.junit.jupiter.api.Test;
 import software.amazon.msk.auth.iam.internals.IAMSaslClient.ClassLoaderAwareIAMSaslClientFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -91,9 +92,9 @@ public class IAMSaslClientTest {
         }, accessKey, secretKey);
     }
 
-    private byte [] getServerResponse(String version, String requestId) throws JsonProcessingException {
+    private byte [] getServerResponse(String version, String requestId) throws JacksonException {
         AuthenticationResponse response = new AuthenticationResponse(version, requestId);
-        return new ObjectMapper().writeValueAsBytes(response);
+        return JsonMapper.builder().build().writeValueAsBytes(response);
     }
 
     @Test
@@ -179,8 +180,9 @@ public class IAMSaslClientTest {
     private byte[] getResponseWithInvalidVersion() {
         AuthenticationResponse response = new AuthenticationResponse(RESPONSE_VERSION, "TEST_REQUEST_ID");
         try {
-            return new ObjectMapper().writeValueAsString(response).replaceAll(RESPONSE_VERSION,"INVALID_VERSION").getBytes();
-        } catch (JsonProcessingException e) {
+            ObjectMapper mapper = JsonMapper.builder().build();
+            return mapper.writeValueAsString(response).replaceAll(RESPONSE_VERSION,"INVALID_VERSION").getBytes();
+        } catch (JacksonException e) {
             throw new RuntimeException("Test failed", e);
         }
     }

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
@@ -15,8 +15,6 @@
 */
 package software.amazon.msk.auth.iam.internals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 
 import java.text.ParseException;
@@ -27,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,7 +56,7 @@ public final class SignedPayloadValidatorUtils {
 
     public static void validatePayload(byte[] payload, AuthenticationRequestParams params)
             throws IOException, ParseException {
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonMapper.builder().build();
         Map<String, String> propertyMap = (Map<String, String>) mapper.readValue(payload, Map.class);
 
         assertEquals(10, propertyMap.size());


### PR DESCRIPTION
*Issue #, if available:* #229

*Description of changes:* 
- Upgrade Jackson to Jackson 3.1.0

This is not a breaking change. Jackson 3 uses different Maven coordinates (tools.jackson.core) and Java packages (tools.jackson.*) than Jackson 2 (com.fasterxml.jackson.core), so the two versions coexist on the classpath without conflict. The only shared artifact — jackson-annotations — remains on com.fasterxml.jackson.annotation by design and is backward compatible. Additionally, the shadow/uber JAR relocates all Jackson classes, making this entirely transparent to consumers.

All changes have been unit tested, and everything works as expected. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
