### PR TITLE
Update shaded Jackson, kafka-clients, commons-lang, log4j dependency …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,26 +43,26 @@ version = readVersion()
 group "software.amazon.msk"
 
 dependencies {
-    compileOnly('org.apache.kafka:kafka-clients:2.8.1')
+    compileOnly('org.apache.kafka:kafka-clients:3.9.1')
     // aws sdk imports.
     implementation(platform('software.amazon.awssdk:bom:2.36.3'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.18.3')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.21.1')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     runtimeOnly('software.amazon.awssdk:apache-client')
 
     //test dependencies
-    testImplementation('org.apache.kafka:kafka-clients:2.2.1')
+    testImplementation('org.apache.kafka:kafka-clients:3.9.1')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.0')
-    testImplementation('org.apache.commons:commons-lang3:3.11')
+    testImplementation('org.apache.commons:commons-lang3:3.18.0')
     testImplementation('org.mockito:mockito-inline:5.0.0')
 
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.0')
-    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.17.1')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.25.3')
     testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.17.1')
 }
 


### PR DESCRIPTION
…used by aws-msk-iam-auth fat jar

*Issue #234*

*This PR makes a minimal dependency-only update to the Jackson, kafka-clients, commons-lang, log4j version used when building the shaded aws-msk-iam-auth fat jar.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
