### PR TITLE
Update shaded Jackson, kafka-clients, commons-lang, log4j dependency …

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The recommended way to use this library is to consume it from maven central whil
   <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>
-      <version>2.3.5</version>
+      <version>2.3.6</version>
   </dependency>
   ```
 If you want to use it with a pre-existing Kafka client, you could build the uber jar and place it in the Kafka client's
@@ -566,6 +566,11 @@ public static String UriEncode(CharSequence input, boolean encodeSlash) {
 ```
    
 ## Release Notes
+
+### Release 2.3.6
+- GHSA-2x2g-32r7-p4x8 addressed by kafka-clients 3.9.1
+- GHSA-72hv-8253-57qq addressed by jackson-databind 2.21.1
+- GHSA-j288-q9x7-2f5v addressed by commons-lang3 3.18.0
 
 ### Release 2.3.5
 - Upgrade AWS SDK version to address CVE-2025-58056 and CVE-2025-58057

--- a/build.gradle
+++ b/build.gradle
@@ -43,26 +43,26 @@ version = readVersion()
 group "software.amazon.msk"
 
 dependencies {
-    compileOnly('org.apache.kafka:kafka-clients:2.8.1')
+    compileOnly('org.apache.kafka:kafka-clients:3.9.1')
     // aws sdk imports.
     implementation(platform('software.amazon.awssdk:bom:2.36.3'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')
     implementation('software.amazon.awssdk:sts')
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.18.3')
+    implementation('com.fasterxml.jackson.core:jackson-databind:2.21.1')
     implementation('org.slf4j:slf4j-api:1.7.25')
 
     runtimeOnly('software.amazon.awssdk:apache-client')
 
     //test dependencies
-    testImplementation('org.apache.kafka:kafka-clients:2.2.1')
+    testImplementation('org.apache.kafka:kafka-clients:3.9.1')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.0')
-    testImplementation('org.apache.commons:commons-lang3:3.11')
+    testImplementation('org.apache.commons:commons-lang3:3.18.0')
     testImplementation('org.mockito:mockito-inline:5.0.0')
 
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.0')
-    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.17.1')
+    testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.25.3')
     testRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.17.1')
 }
 


### PR DESCRIPTION
…used by aws-msk-iam-auth fat jar

Issue https://github.com/aws/aws-msk-iam-auth/issues/234

This PR makes a minimal dependency-only update to the Jackson, kafka-clients, commons-lang, log4j version used when building the shaded aws-msk-iam-auth fat jar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.