### PR TITLE
Feat/custom region provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,12 @@ You can override this behavior by specifying a custom region provider via the `a
 
 ```properties
 sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
-  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider?host=region.my-cluster.example.com";
+  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider?host=region.my-cluster.example.com;refresh.seconds=60";
 ```
 
-The library ships with `Route53RegionProvider`, which resolves the region by performing a DNS TXT record lookup. It accepts an optional `host` parameter:
-- When `host` is provided, it is used directly as the DNS lookup name.
-- When `host` is omitted, the broker hostname is prefixed with `region.` to form the lookup name (e.g. `region.broker.example.com`).
+The library ships with `Route53RegionProvider`, which resolves the region by performing a DNS TXT record lookup. It accepts the following optional parameters:
+- `host` — when provided, it is used directly as the DNS lookup name. When omitted, the broker hostname is prefixed with `region.` to form the lookup name (e.g. `region.broker.example.com`).
+- `refresh.seconds` — cache TTL in seconds for the resolved region. Defaults to `60` (1 minute). Set to `0` to disable caching and resolve DNS on every call.
 
 The TXT record value is expected to contain a valid AWS region id (e.g. `us-east-1`).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The recommended way to use this library is to consume it from maven central whil
   <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>
-      <version>2.3.5</version>
+      <version>2.3.6</version>
   </dependency>
   ```
 If you want to use it with a pre-existing Kafka client, you could build the uber jar and place it in the Kafka client's
@@ -190,6 +190,57 @@ sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required awsMaxRetr
 This sets the maximum number of retries to `7` and the maximum back off time to `500 ms`.
 
 The retries can be turned off completely by setting `awsMaxRetries` to `"0"`.
+
+### Custom Region Provider
+
+By default, the library extracts the AWS region from the MSK broker hostname. If the region cannot be determined from the hostname, it falls back to the `DefaultAwsRegionProviderChain`.
+
+You can override this behavior by specifying a custom region provider via the `awsMskRegionProvider` JAAS config option. The value is a descriptor string in the format `className?param1=value1;param2=value2`. The referenced class must implement the `ConfigurableRegionProvider` interface and provide a constructor that accepts a `Map<String, String>`.
+
+```properties
+sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
+  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider?host=region.my-cluster.example.com";
+```
+
+The library ships with `Route53RegionProvider`, which resolves the region by performing a DNS TXT record lookup. It accepts an optional `host` parameter:
+- When `host` is provided, it is used directly as the DNS lookup name.
+- When `host` is omitted, the broker hostname is prefixed with `region.` to form the lookup name (e.g. `region.broker.example.com`).
+
+The TXT record value is expected to contain a valid AWS region id (e.g. `us-east-1`).
+
+If the custom region provider returns null or throws an exception, a warning is logged and the library falls back to the `DefaultAwsRegionProviderChain`.
+
+You can also implement your own provider by implementing the `ConfigurableRegionProvider` interface:
+
+```java
+package com.example;
+
+import java.util.Map;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
+
+public class MyRegionProvider implements ConfigurableRegionProvider {
+    public MyRegionProvider(Map<String, String> config) {
+        // initialize from config params
+    }
+
+    @Override
+    public Region getRegion() {
+        return getRegion(null);
+    }
+
+    @Override
+    public Region getRegion(String host) {
+        return Region.of("eu-west-1");
+    }
+}
+```
+
+Then reference it in your JAAS config:
+```properties
+sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
+  awsMskRegionProvider="com.example.MyRegionProvider?myParam=myValue";
+```
 
 
 ## Setting EKS Service Account
@@ -566,6 +617,12 @@ public static String UriEncode(CharSequence input, boolean encodeSlash) {
 ```
    
 ## Release Notes
+
+### Release 2.3.6
+- Add `awsMskRegionProvider` JAAS config option for custom region resolution via `ConfigurableRegionProvider` interface
+- Add built-in `Route53RegionProvider` that resolves regions from DNS TXT records
+- Graceful fallback to `DefaultAwsRegionProviderChain` when custom region provider fails or returns null
+- Remove unused `DynamicAwsRegionProviderChain` class
 
 ### Release 2.3.5
 - Upgrade AWS SDK version to address CVE-2025-58056 and CVE-2025-58057

--- a/src/main/java/software/amazon/msk/auth/iam/IAMClientCallbackHandler.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMClientCallbackHandler.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
+
 /**
  * This client callback handler is used to extract AWSCredentials.
  * The credentials are based on JaasConfig options passed to {@link IAMLoginModule}.
@@ -41,6 +43,7 @@ import java.util.Optional;
 public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(IAMClientCallbackHandler.class);
     private AwsCredentialsProvider provider;
+    private ConfigurableRegionProvider customRegionProvider;
 
     @Override
     public void configure(Map<String, ?> configs,
@@ -51,8 +54,14 @@ public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
         }
         final Optional<AppConfigurationEntry> configEntry = jaasConfigEntries.stream()
                 .filter(j -> IAMLoginModule.class.getCanonicalName().equals(j.getLoginModuleName())).findFirst();
-        provider = configEntry.map(c -> (AwsCredentialsProvider) new MSKCredentialProvider(c.getOptions()))
-                .orElse(DefaultCredentialsProvider.create());
+        configEntry.ifPresent(c -> {
+            MSKCredentialProvider mskProvider = new MSKCredentialProvider(c.getOptions());
+            provider = mskProvider;
+            customRegionProvider = mskProvider.getCustomRegionProvider();
+        });
+        if (provider == null) {
+            provider = DefaultCredentialsProvider.create();
+        }
     }
 
     @Override
@@ -97,6 +106,7 @@ public class IAMClientCallbackHandler implements AuthenticateCallbackHandler {
         }
         try {
             callback.setAwsCredentials(provider.resolveCredentials());
+            callback.setCustomRegionProvider(customRegionProvider);
         } catch (Exception e) {
             callback.setLoadingException(e);
         }

--- a/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandler.java
+++ b/src/main/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandler.java
@@ -42,10 +42,10 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.msk.auth.iam.internals.AWS4SignedPayloadGenerator;
 import software.amazon.msk.auth.iam.internals.AuthenticationRequestParams;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 import software.amazon.msk.auth.iam.internals.MSKCredentialProvider;
 import software.amazon.msk.auth.iam.internals.UserAgentUtils;
 
@@ -62,7 +62,7 @@ public class IAMOAuthBearerLoginCallbackHandler implements AuthenticateCallbackH
     private final AWS4SignedPayloadGenerator aws4Signer = new AWS4SignedPayloadGenerator();
 
     private AwsCredentialsProvider credentialsProvider;
-    private AwsRegionProvider awsRegionProvider;
+    private ConfigurableRegionProvider awsRegionProvider;
     private boolean configured = false;
 
     /**
@@ -85,10 +85,30 @@ public class IAMOAuthBearerLoginCallbackHandler implements AuthenticateCallbackH
                         .equals(j.getLoginModuleName()))
                 .findFirst();
 
-        credentialsProvider = configEntry.map(c -> (AwsCredentialsProvider) new MSKCredentialProvider(c.getOptions()))
-                .orElse(DefaultCredentialsProvider.create());
+        credentialsProvider = configEntry.map(c -> {
+            MSKCredentialProvider mskProvider = new MSKCredentialProvider(c.getOptions());
+            ConfigurableRegionProvider custom = mskProvider.getCustomRegionProvider();
+            if (custom != null) {
+                awsRegionProvider = custom;
+            }
+            return (AwsCredentialsProvider) mskProvider;
+        }).orElse(DefaultCredentialsProvider.create());
 
-        awsRegionProvider = new DefaultAwsRegionProviderChain();
+        if (awsRegionProvider == null) {
+            // Wrap DefaultAwsRegionProviderChain as a ConfigurableRegionProvider fallback
+            final DefaultAwsRegionProviderChain defaultChain = new DefaultAwsRegionProviderChain();
+            awsRegionProvider = new ConfigurableRegionProvider() {
+                @Override
+                public Region getRegion(String host) {
+                    return defaultChain.getRegion();
+                }
+
+                @Override
+                public Region getRegion() {
+                    return defaultChain.getRegion();
+                }
+            };
+        }
         configured = true;
     }
 

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AWSCredentialsCallback.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AWSCredentialsCallback.java
@@ -17,8 +17,10 @@ package software.amazon.msk.auth.iam.internals;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.msk.auth.iam.IAMClientCallbackHandler;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 
 import javax.security.auth.callback.Callback;
 
@@ -33,6 +35,9 @@ public class AWSCredentialsCallback implements Callback {
     private AwsCredentials awsCredentials = null;
     @Getter
     private Exception loadingException = null;
+    @Getter
+    @Setter
+    private ConfigurableRegionProvider customRegionProvider = null;
 
     public void setAwsCredentials(@NonNull AwsCredentials awsCredentials) {
         this.awsCredentials = awsCredentials;

--- a/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/AuthenticationRequestParams.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 import software.amazon.msk.auth.iam.internals.utils.RegionUtils;
 
 /**
@@ -54,7 +55,14 @@ public class AuthenticationRequestParams {
     public static AuthenticationRequestParams create(@NonNull String host,
         AwsCredentials credentials,
         @NonNull String userAgent) throws IllegalArgumentException {
-        Region region = RegionUtils.extractRegionFromHost(host);
+        return create(host, credentials, userAgent, null);
+    }
+
+    public static AuthenticationRequestParams create(@NonNull String host,
+        AwsCredentials credentials,
+        @NonNull String userAgent,
+        ConfigurableRegionProvider regionProvider) throws IllegalArgumentException {
+        Region region = RegionUtils.extractRegionFromHost(host, regionProvider);
         if (region == null) {
             throw new IllegalArgumentException("Host " + host + " does not belong to a valid region.");
         }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/IAMSaslClient.java
@@ -141,7 +141,8 @@ public class IAMSaslClient implements SaslClient {
             //Generate the signed payload
             final byte[] response = payloadGenerator.signedPayload(
                     AuthenticationRequestParams
-                            .create(serverName, callback.getAwsCredentials(), UserAgentUtils.getUserAgentValue()));
+                            .create(serverName, callback.getAwsCredentials(), UserAgentUtils.getUserAgentValue(),
+                                    callback.getCustomRegionProvider()));
             //transition to the state waiting to receive server response.
             setState(State.RECEIVE_SERVER_RESPONSE);
             return response;

--- a/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/MSKCredentialProvider.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 
 /**
  * This AWS Credential Provider is used to load up AWS Credentials based on options provided on the Jaas config line.
@@ -94,6 +95,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
     private static final String AWS_SHOULD_USE_FIPS = "awsShouldUseFips";
     private static final String AWS_MAX_RETRIES = "awsMaxRetries";
     private static final String AWS_MAX_BACK_OFF_TIME_MS = "awsMaxBackOffTimeMs";
+    private static final String AWS_REGION_PROVIDER_DEF = "awsMskRegionProvider";
     private static final String GLOBAL_REGION = "aws-global";
     private static final int DEFAULT_MAX_RETRIES = 3;
     private static final int DEFAULT_MAX_BACK_OFF_TIME_MS = 5000;
@@ -105,6 +107,8 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
     private final Boolean shouldDebugCreds;
     private final String stsRegion;
     private final RetryPolicy retryPolicy;
+    @Getter
+    private final ConfigurableRegionProvider customRegionProvider;
 
     public MSKCredentialProvider(Map<String, ?> options) {
         this(new ProviderBuilder(options));
@@ -112,7 +116,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
 
     MSKCredentialProvider(ProviderBuilder builder) {
         this(builder.getProviders(), builder.shouldDebugCreds(), builder.getStsRegion(), builder.getMaxRetries(),
-                builder.getMaxBackOffTimeMs(), builder.addDefaultProviders());
+                builder.getMaxBackOffTimeMs(), builder.addDefaultProviders(), builder.getCustomRegionProvider());
     }
 
     MSKCredentialProvider(List<AwsCredentialsProvider> providers,
@@ -120,7 +124,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                           String stsRegion,
                           int maxRetries,
                           int maxBackOffTimeMs) {
-        this(providers, shouldDebugCreds, stsRegion, maxRetries, maxBackOffTimeMs, true);
+        this(providers, shouldDebugCreds, stsRegion, maxRetries, maxBackOffTimeMs, true, null);
     }
 
     MSKCredentialProvider(List<AwsCredentialsProvider> providers,
@@ -129,6 +133,16 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
                           int maxRetries,
                           int maxBackOffTimeMs,
                           boolean addDefaultProviders) {
+        this(providers, shouldDebugCreds, stsRegion, maxRetries, maxBackOffTimeMs, addDefaultProviders, null);
+    }
+
+    MSKCredentialProvider(List<AwsCredentialsProvider> providers,
+                          Boolean shouldDebugCreds,
+                          String stsRegion,
+                          int maxRetries,
+                          int maxBackOffTimeMs,
+                          boolean addDefaultProviders,
+                          ConfigurableRegionProvider customRegionProvider) {
         AwsCredentialsProviderChain.Builder chain = AwsCredentialsProviderChain.builder();
         chain.credentialsProviders(providers);
         if (addDefaultProviders) {
@@ -141,6 +155,7 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
             .collect(Collectors.toList());
         this.shouldDebugCreds = shouldDebugCreds;
         this.stsRegion = stsRegion;
+        this.customRegionProvider = customRegionProvider;
         BackoffStrategy backoffStrategy = FullJitterBackoffStrategy.builder()
             .baseDelay(BASE_DELAY)
             .maxBackoffTime(Duration.ofMillis(maxBackOffTimeMs))
@@ -288,6 +303,23 @@ public class MSKCredentialProvider implements AwsCredentialsProvider, AutoClosea
         public String getStsRegion() {
             return Optional.ofNullable((String) optionsMap.get(AWS_STS_REGION))
                     .orElse(GLOBAL_REGION);
+        }
+
+        /**
+         * Instantiate a custom {@link ConfigurableRegionProvider} from the descriptor specified
+         * in the JAAS config option {@code awsMskRegionProvider}.
+         * The descriptor format is {@code className?param1=value1;param2=value2}.
+         *
+         * @return the custom region provider, or {@code null} if not configured.
+         */
+        public ConfigurableRegionProvider getCustomRegionProvider() {
+            ConfigurableRegionProvider customRegionProvider = Optional.ofNullable((String) optionsMap.get(AWS_REGION_PROVIDER_DEF))
+                    .map(ConfigurableRegionProvider::getInstance)
+                    .orElse(null);
+            if (customRegionProvider != null){
+                log.info("Custom region provider defined: {}", customRegionProvider.getClass());
+            }
+            return customRegionProvider;
         }
 
         public int getMaxRetries() {

--- a/src/main/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProvider.java
@@ -1,0 +1,108 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package software.amazon.msk.auth.iam.internals.region;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+/**
+ * Extension of {@link AwsRegionProvider} that supports configuration via a
+ * parameter map. Implementations must provide a constructor that accepts a
+ * {@code Map<String, String>} of configuration parameters.
+ *
+ * <p>The static {@link #getInstance(String)} factory parses a descriptor string
+ * in the format {@code className?param1=value1;param2=value2} and instantiates
+ * the target class by passing the parsed parameters to its map constructor.</p>
+ */
+public interface ConfigurableRegionProvider extends AwsRegionProvider {
+
+    /**
+     * Resolve the region using a provided host as context.
+     *
+     * @param host the host to use for region resolution
+     * @return the resolved AWS {@link Region}
+     */
+    Region getRegion(String host);
+
+    /**
+     * Parse a descriptor string and instantiate the corresponding
+     * {@link ConfigurableRegionProvider}.
+     *
+     * <p>Descriptor format: {@code fully.qualified.ClassName?key1=val1;key2=val2}
+     * <br>The query-string portion is optional. When omitted an empty map is
+     * passed to the constructor.</p>
+     *
+     * @param descriptor class name with optional parameters
+     * @return a configured instance of the provider
+     * @throws IllegalArgumentException if the descriptor is null/blank or
+     *         the class cannot be instantiated
+     */
+    static ConfigurableRegionProvider getInstance(String descriptor) {
+        if (descriptor == null || descriptor.isBlank()) {
+            throw new IllegalArgumentException("Region provider descriptor must not be null or blank");
+        }
+
+        String className;
+        Map<String, String> params;
+
+        int queryIdx = descriptor.indexOf('?');
+        if (queryIdx < 0) {
+            className = descriptor.trim();
+            params = Collections.emptyMap();
+        } else {
+            className = descriptor.substring(0, queryIdx).trim();
+            params = parseParams(descriptor.substring(queryIdx + 1));
+        }
+
+        try {
+            Class<?> clazz = Class.forName(className);
+            return (ConfigurableRegionProvider) clazz
+                    .getDeclaredConstructor(Map.class)
+                    .newInstance(params);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(
+                    className + " does not implement ConfigurableRegionProvider", e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Failed to instantiate ConfigurableRegionProvider: " + className, e);
+        }
+    }
+
+    private static Map<String, String> parseParams(String queryString) {
+        Map<String, String> params = new LinkedHashMap<>();
+        if (queryString == null || queryString.isBlank()) {
+            return params;
+        }
+        for (String pair : queryString.split(";")) {
+            String trimmed = pair.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int eqIdx = trimmed.indexOf('=');
+            if (eqIdx < 0) {
+                params.put(trimmed, "");
+            } else {
+                params.put(trimmed.substring(0, eqIdx).trim(),
+                           trimmed.substring(eqIdx + 1).trim());
+            }
+        }
+        return params;
+    }
+}

--- a/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
@@ -1,0 +1,128 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package software.amazon.msk.auth.iam.internals.region;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * A {@link ConfigurableRegionProvider} that resolves the AWS region by performing
+ * a DNS TXT record lookup via Route 53.
+ *
+ * <p>Configuration parameters (passed via constructor map):</p>
+ * <ul>
+ *   <li>{@code host} — optional fully-qualified hostname to query for the TXT record.
+ *       When provided, this value is used directly as the DNS lookup name.</li>
+ * </ul>
+ *
+ * <p>When no {@code host} is configured, the {@link #getRegion(String)} method
+ * constructs the lookup name by prefixing the supplied host with {@code "region."}
+ * (e.g. {@code "region.broker.example.com"}).</p>
+ *
+ * <p>The TXT record value is expected to contain a valid AWS region id
+ * (e.g. {@code "us-east-1"}).</p>
+ */
+public class Route53RegionProvider implements ConfigurableRegionProvider {
+    private static final String REGION_PREFIX = "region.";
+    private static final Logger log = LoggerFactory.getLogger(Route53RegionProvider.class);
+    private static final String HOST_KEY = "host";
+
+    private final String host;
+
+    public Route53RegionProvider(Map<String, String> config) {
+        this.host = config != null ? config.get(HOST_KEY) : null;
+        if (log.isDebugEnabled()) {
+            log.debug("Route53RegionProvider initialized with host={}", this.host);
+        }
+    }
+
+    /**
+     * Resolve the region using the configured host. Throws if no host was
+     * configured and no fallback host is available.
+     */
+    @Override
+    public Region getRegion() {
+        return getRegion(null);
+    }
+
+    /**
+     * Resolve the region by looking up a DNS TXT record.
+     *
+     * <p>If a {@code host} was provided at construction time, that value is used
+     * as the DNS name. Otherwise the given {@code host} parameter is prefixed
+     * with {@code "region."} to form the lookup name.</p>
+     *
+     * @param host fallback host used when no host was configured at construction
+     * @return the resolved AWS {@link Region}
+     * @throws SdkClientException if the region cannot be resolved
+     */
+    public Region getRegion(String host) {
+        String lookupHost = this.host != null ? this.host : buildLookupHost(host);
+        if (lookupHost == null || lookupHost.isBlank()) {
+            throw SdkClientException.create(
+                    "Cannot resolve region: no host configured and no host parameter provided");
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving region via TXT record for host: {}", lookupHost);
+        }
+        String regionId = resolveTxtRecord(lookupHost);
+        return Region.of(regionId);
+    }
+
+    private String buildLookupHost(String host) {
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        return REGION_PREFIX + host;
+    }
+
+    private String resolveTxtRecord(String lookupHost) {
+        try {
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put(DirContext.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+            DirContext ctx = new InitialDirContext(env);
+            try {
+                Attributes attrs = ctx.getAttributes(lookupHost, new String[]{"TXT"});
+                Attribute txtAttr = attrs.get("TXT");
+                if (txtAttr == null || txtAttr.size() == 0) {
+                    throw SdkClientException.create(
+                            "No TXT record found for host: " + lookupHost);
+                }
+                NamingEnumeration<?> values = txtAttr.getAll();
+                String value = (String) values.next();
+                // TXT records may be quoted
+                return value.replace("\"", "").trim();
+            } finally {
+                ctx.close();
+            }
+        } catch (NamingException e) {
+            throw SdkClientException.create(
+                    "Failed to resolve TXT record for host: " + lookupHost, e);
+        }
+    }
+}

--- a/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
@@ -41,8 +41,15 @@ import software.amazon.awssdk.regions.Region;
  * <ul>
  *   <li>{@code host} — optional fully-qualified hostname to query for the TXT record.
  *       When provided, this value is used directly as the DNS lookup name.</li>
- *   <li>{@code refresh.seconds} — optional cache TTL in seconds. Defaults to 300 (5 minutes).
- *       Set to 0 to disable caching.</li>
+ *   <li>{@code refresh.seconds} — how often, in seconds, the cached region value
+ *       is refreshed via a new DNS lookup. Defaults to 60 (1 minute).
+ *       Set to 0 to disable caching and resolve DNS on every call.
+ *       Uses lazy evaluation: the cache is only refreshed when an authentication
+ *       request needs to be signed, which typically happens during initial
+ *       authentication with MSK and subsequent re-authentication to refresh
+ *       session tokens. Caching reduces the number of Route 53 DNS calls,
+ *       which is especially beneficial when authentication is retried
+ *       repeatedly due to failures.</li>
  * </ul>
  *
  * <p>When no {@code host} is configured, the {@link #getRegion(String)} method
@@ -55,9 +62,10 @@ import software.amazon.awssdk.regions.Region;
 public class Route53RegionProvider implements ConfigurableRegionProvider {
     private static final Logger log = LoggerFactory.getLogger(Route53RegionProvider.class);
     private static final String HOST_KEY = "host";
+
     private static final String REFRESH_SECONDS_KEY = "refresh.seconds";
     private static final String REGION_PREFIX = "region.";
-    private static final long DEFAULT_REFRESH_SECONDS = 15;
+    private static final long DEFAULT_REFRESH_SECONDS = 60;
 
     private final String host;
     private final long refreshSeconds;
@@ -122,6 +130,20 @@ public class Route53RegionProvider implements ConfigurableRegionProvider {
         return REGION_PREFIX + host;
     }
 
+
+    /**
+     * Resolves a DNS TXT record for the given hostname using JNDI with the
+     * {@code com.sun.jndi.dns.DnsContextFactory} built-in JDK DNS provider.
+     *
+     * <p>Only the first TXT record value is used. This is intentional — the
+     * TXT record is expected to be a dedicated, environment-controlled record
+     * whose sole value is the active AWS region id. Surrounding quotes are
+     * stripped from the returned value.</p>
+     *
+     * @param lookupHost the fully-qualified hostname to query
+     * @return the TXT record value (unquoted and trimmed)
+     * @throws SdkClientException if no TXT record is found or the DNS lookup fails
+     */
     String resolveTxtRecord(String lookupHost) {
         try {
             Hashtable<String, String> env = new Hashtable<>();

--- a/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProvider.java
@@ -15,8 +15,11 @@
 */
 package software.amazon.msk.auth.iam.internals.region;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -32,12 +35,14 @@ import software.amazon.awssdk.regions.Region;
 
 /**
  * A {@link ConfigurableRegionProvider} that resolves the AWS region by performing
- * a DNS TXT record lookup via Route 53.
+ * a DNS TXT record lookup via Route 53, with time-based caching.
  *
  * <p>Configuration parameters (passed via constructor map):</p>
  * <ul>
  *   <li>{@code host} — optional fully-qualified hostname to query for the TXT record.
  *       When provided, this value is used directly as the DNS lookup name.</li>
+ *   <li>{@code refresh.seconds} — optional cache TTL in seconds. Defaults to 300 (5 minutes).
+ *       Set to 0 to disable caching.</li>
  * </ul>
  *
  * <p>When no {@code host} is configured, the {@link #getRegion(String)} method
@@ -48,50 +53,66 @@ import software.amazon.awssdk.regions.Region;
  * (e.g. {@code "us-east-1"}).</p>
  */
 public class Route53RegionProvider implements ConfigurableRegionProvider {
-    private static final String REGION_PREFIX = "region.";
     private static final Logger log = LoggerFactory.getLogger(Route53RegionProvider.class);
     private static final String HOST_KEY = "host";
+    private static final String REFRESH_SECONDS_KEY = "refresh.seconds";
+    private static final String REGION_PREFIX = "region.";
+    private static final long DEFAULT_REFRESH_SECONDS = 15;
 
     private final String host;
+    private final long refreshSeconds;
+    private final Clock clock;
+    private final ConcurrentHashMap<String, CachedRegion> cache = new ConcurrentHashMap<>();
 
     public Route53RegionProvider(Map<String, String> config) {
+        this(config, Clock.systemUTC());
+    }
+
+    // Visible for testing
+    Route53RegionProvider(Map<String, String> config, Clock clock) {
         this.host = config != null ? config.get(HOST_KEY) : null;
+        this.refreshSeconds = parseRefreshSeconds(config);
+        this.clock = clock;
         if (log.isDebugEnabled()) {
-            log.debug("Route53RegionProvider initialized with host={}", this.host);
+            log.debug("Route53RegionProvider initialized with host={}, refresh.seconds={}",
+                    this.host, this.refreshSeconds);
         }
     }
 
-    /**
-     * Resolve the region using the configured host. Throws if no host was
-     * configured and no fallback host is available.
-     */
     @Override
     public Region getRegion() {
         return getRegion(null);
     }
 
-    /**
-     * Resolve the region by looking up a DNS TXT record.
-     *
-     * <p>If a {@code host} was provided at construction time, that value is used
-     * as the DNS name. Otherwise the given {@code host} parameter is prefixed
-     * with {@code "region."} to form the lookup name.</p>
-     *
-     * @param host fallback host used when no host was configured at construction
-     * @return the resolved AWS {@link Region}
-     * @throws SdkClientException if the region cannot be resolved
-     */
+    @Override
     public Region getRegion(String host) {
         String lookupHost = this.host != null ? this.host : buildLookupHost(host);
         if (lookupHost == null || lookupHost.isBlank()) {
             throw SdkClientException.create(
                     "Cannot resolve region: no host configured and no host parameter provided");
         }
+
+        if (refreshSeconds > 0) {
+            CachedRegion cached = cache.get(lookupHost);
+            if (cached != null && !cached.isExpired(clock.instant(), refreshSeconds)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Returning cached region {} for host: {}", cached.region.id(), lookupHost);
+                }
+                return cached.region;
+            }
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("Resolving region via TXT record for host: {}", lookupHost);
         }
         String regionId = resolveTxtRecord(lookupHost);
-        return Region.of(regionId);
+        Region region = Region.of(regionId);
+
+        if (refreshSeconds > 0) {
+            cache.put(lookupHost, new CachedRegion(region, clock.instant()));
+        }
+
+        return region;
     }
 
     private String buildLookupHost(String host) {
@@ -101,7 +122,7 @@ public class Route53RegionProvider implements ConfigurableRegionProvider {
         return REGION_PREFIX + host;
     }
 
-    private String resolveTxtRecord(String lookupHost) {
+    String resolveTxtRecord(String lookupHost) {
         try {
             Hashtable<String, String> env = new Hashtable<>();
             env.put(DirContext.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
@@ -115,7 +136,6 @@ public class Route53RegionProvider implements ConfigurableRegionProvider {
                 }
                 NamingEnumeration<?> values = txtAttr.getAll();
                 String value = (String) values.next();
-                // TXT records may be quoted
                 return value.replace("\"", "").trim();
             } finally {
                 ctx.close();
@@ -123,6 +143,38 @@ public class Route53RegionProvider implements ConfigurableRegionProvider {
         } catch (NamingException e) {
             throw SdkClientException.create(
                     "Failed to resolve TXT record for host: " + lookupHost, e);
+        }
+    }
+
+    private static long parseRefreshSeconds(Map<String, String> config) {
+        if (config == null) {
+            return DEFAULT_REFRESH_SECONDS;
+        }
+        String value = config.get(REFRESH_SECONDS_KEY);
+        if (value == null || value.isBlank()) {
+            return DEFAULT_REFRESH_SECONDS;
+        }
+        try {
+            long parsed = Long.parseLong(value.trim());
+            return Math.max(0, parsed);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid value for {}: '{}'. Using default {}s.",
+                    REFRESH_SECONDS_KEY, value, DEFAULT_REFRESH_SECONDS);
+            return DEFAULT_REFRESH_SECONDS;
+        }
+    }
+
+    private static class CachedRegion {
+        final Region region;
+        final Instant resolvedAt;
+
+        CachedRegion(Region region, Instant resolvedAt) {
+            this.region = region;
+            this.resolvedAt = resolvedAt;
+        }
+
+        boolean isExpired(Instant now, long refreshSeconds) {
+            return resolvedAt.plusSeconds(refreshSeconds).isBefore(now);
         }
     }
 }

--- a/src/main/java/software/amazon/msk/auth/iam/internals/utils/RegionUtils.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/utils/RegionUtils.java
@@ -1,9 +1,14 @@
 package software.amazon.msk.auth.iam.internals.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 
 public class RegionUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(RegionUtils.class);
 
   /**
    * Try to extract the region from the host. If the region is not found, return the default region
@@ -13,9 +18,41 @@ public class RegionUtils {
    * @return The region extracted from the host.
    */
   public static Region extractRegionFromHost(String host) {
+    return extractRegionFromHost(host, null);
+  }
+
+  /**
+   * Try to extract the region from the host. If the region is not found, use the provided
+   * custom region provider. If no custom provider is given, fall back to the
+   * DefaultAwsRegionProviderChain. If the custom provider fails or returns null,
+   * a warning is logged and the DefaultAwsRegionProviderChain is used as fallback.
+   *
+   * @param host           The host to extract the region from.
+   * @param regionProvider An optional custom region provider to use as fallback. May be null.
+   * @return The region extracted from the host or resolved by the provider.
+   */
+  public static Region extractRegionFromHost(String host, ConfigurableRegionProvider regionProvider) {
     return Region.regions().stream()
         .filter(region -> host.contains(region.id()))
         .findFirst()
-        .orElseGet(() -> DefaultAwsRegionProviderChain.builder().build().getRegion());
+        .orElseGet(() -> {
+          if (regionProvider != null) {
+            try {
+              log.info("Trying region provider {}", regionProvider.getClass());
+              Region region = regionProvider.getRegion(host);
+
+              if (region != null) {
+                return region;
+              }
+              log.warn("Custom region provider returned null for host: {}. "
+                  + "Falling back to DefaultAwsRegionProviderChain.", host);
+            } catch (Exception e) {
+              log.warn("Custom region provider failed for host: {}. "
+                  + "Falling back to DefaultAwsRegionProviderChain.", host, e);
+            }
+          }
+          log.info("Falling back to DefaultAwsRegionProviderChain");
+          return DefaultAwsRegionProviderChain.builder().build().getRegion();
+        });
   }
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 #Updated on 2025-10-29T16:45:00Z
 platform=java
-version=2.3.5
+version=2.3.6

--- a/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/AuthenticateRequestParamsTest.java
@@ -22,10 +22,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
 import software.amazon.msk.auth.iam.internals.utils.RegionUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class AuthenticateRequestParamsTest {
     private static final String VALID_HOSTNAME = "b-3.unit-test.abcdef.kafka.us-west-2.amazonaws.com";
@@ -57,7 +61,7 @@ public class AuthenticateRequestParamsTest {
     public void testInvalidHost() {
         try(MockedStatic<RegionUtils> mockStatic = Mockito.mockStatic(RegionUtils.class)) {
             mockStatic
-                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION))
+                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION, null))
                 .thenReturn(null);
 
             assertThrows(IllegalArgumentException.class,
@@ -69,11 +73,39 @@ public class AuthenticateRequestParamsTest {
     public void testInvalidHostInEC2() {
         try(MockedStatic<RegionUtils> mockStatic = Mockito.mockStatic(RegionUtils.class)) {
             mockStatic
-                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION))
+                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION, null))
                 .thenReturn(Region.US_WEST_1);
 
             AuthenticationRequestParams params = AuthenticationRequestParams.create(HOSTNAME_NO_REGION, credentials, USER_AGENT);
             assertEquals(Region.US_WEST_1, params.getRegion());
+        }
+    }
+
+    @Test
+    public void testCreateWithCustomRegionProvider() {
+        ConfigurableRegionProvider mockProvider = mock(ConfigurableRegionProvider.class);
+
+        try (MockedStatic<RegionUtils> mockStatic = Mockito.mockStatic(RegionUtils.class)) {
+            mockStatic
+                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION, mockProvider))
+                .thenReturn(Region.EU_CENTRAL_1);
+
+            AuthenticationRequestParams params = AuthenticationRequestParams
+                    .create(HOSTNAME_NO_REGION, credentials, USER_AGENT, mockProvider);
+            assertEquals(Region.EU_CENTRAL_1, params.getRegion());
+        }
+    }
+
+    @Test
+    public void testCreateWithNullRegionProviderFallsBack() {
+        try (MockedStatic<RegionUtils> mockStatic = Mockito.mockStatic(RegionUtils.class)) {
+            mockStatic
+                .when(() -> RegionUtils.extractRegionFromHost(HOSTNAME_NO_REGION, null))
+                .thenReturn(Region.US_EAST_1);
+
+            AuthenticationRequestParams params = AuthenticationRequestParams
+                    .create(HOSTNAME_NO_REGION, credentials, USER_AGENT, null);
+            assertEquals(Region.US_EAST_1, params.getRegion());
         }
     }
 }

--- a/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/MSKCredentialProviderTest.java
@@ -29,6 +29,9 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
+import software.amazon.msk.auth.iam.internals.region.TestRegionProvider;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -50,6 +53,8 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
@@ -818,6 +823,53 @@ public class MSKCredentialProviderTest {
             assertEquals(ACCESS_KEY_VALUE, credentials.accessKeyId());
             assertEquals(SECRET_KEY_VALUE, credentials.secretAccessKey());
 
+        }, ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
+    }
+
+    @Test
+    public void testCustomRegionProviderFromOptions() {
+        Map<String, String> optionsMap = new HashMap<>();
+        optionsMap.put("awsMskRegionProvider",
+                TestRegionProvider.class.getName() + "?region=eu-central-1");
+
+        MSKCredentialProvider.ProviderBuilder builder = new MSKCredentialProvider.ProviderBuilder(optionsMap);
+        ConfigurableRegionProvider regionProvider = builder.getCustomRegionProvider();
+
+        assertNotNull(regionProvider);
+        assertTrue(regionProvider instanceof TestRegionProvider);
+        assertEquals(software.amazon.awssdk.regions.Region.EU_CENTRAL_1,
+                regionProvider.getRegion("any-host"));
+    }
+
+    @Test
+    public void testCustomRegionProviderNotConfigured() {
+        Map<String, String> optionsMap = new HashMap<>();
+
+        MSKCredentialProvider.ProviderBuilder builder = new MSKCredentialProvider.ProviderBuilder(optionsMap);
+        ConfigurableRegionProvider regionProvider = builder.getCustomRegionProvider();
+
+        assertNull(regionProvider);
+    }
+
+    @Test
+    public void testCustomRegionProviderInvalidClass() {
+        Map<String, String> optionsMap = new HashMap<>();
+        optionsMap.put("awsMskRegionProvider", "com.nonexistent.FakeProvider");
+
+        MSKCredentialProvider.ProviderBuilder builder = new MSKCredentialProvider.ProviderBuilder(optionsMap);
+        assertThrows(IllegalArgumentException.class, builder::getCustomRegionProvider);
+    }
+
+    @Test
+    public void testCustomRegionProviderStoredOnProvider() {
+        runTestWithSystemPropertyCredentials(() -> {
+            Map<String, String> optionsMap = new HashMap<>();
+            optionsMap.put("awsMskRegionProvider",
+                    TestRegionProvider.class.getName() + "?region=us-west-2");
+
+            MSKCredentialProvider provider = new MSKCredentialProvider(optionsMap);
+            assertNotNull(provider.getCustomRegionProvider());
+            assertTrue(provider.getCustomRegionProvider() instanceof TestRegionProvider);
         }, ACCESS_KEY_VALUE, SECRET_KEY_VALUE);
     }
 }

--- a/src/test/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProviderTest.java
@@ -1,0 +1,90 @@
+package software.amazon.msk.auth.iam.internals.region;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConfigurableRegionProviderTest {
+
+    private static final String TEST_PROVIDER_CLASS = TestRegionProvider.class.getName();
+
+    @Test
+    public void testGetInstanceWithClassNameOnly() {
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(TEST_PROVIDER_CLASS);
+        assertNotNull(provider);
+        assertTrue(provider instanceof TestRegionProvider);
+        TestRegionProvider testProvider = (TestRegionProvider) provider;
+        assertTrue(testProvider.getConfig().isEmpty());
+    }
+
+    @Test
+    public void testGetInstanceWithParams() {
+        String descriptor = TEST_PROVIDER_CLASS + "?region=eu-west-1;key2=value2";
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(descriptor);
+        assertNotNull(provider);
+        TestRegionProvider testProvider = (TestRegionProvider) provider;
+        assertEquals("eu-west-1", testProvider.getConfig().get("region"));
+        assertEquals("value2", testProvider.getConfig().get("key2"));
+    }
+
+    @Test
+    public void testGetInstanceWithParamNoValue() {
+        String descriptor = TEST_PROVIDER_CLASS + "?flagParam";
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(descriptor);
+        TestRegionProvider testProvider = (TestRegionProvider) provider;
+        assertEquals("", testProvider.getConfig().get("flagParam"));
+    }
+
+    @Test
+    public void testGetInstanceReturnsCorrectRegion() {
+        String descriptor = TEST_PROVIDER_CLASS + "?region=ap-southeast-1";
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(descriptor);
+        assertEquals(Region.AP_SOUTHEAST_1, provider.getRegion("some-host"));
+    }
+
+    @Test
+    public void testGetInstanceWithWhitespace() {
+        String descriptor = "  " + TEST_PROVIDER_CLASS + "  ?  region=us-west-2  ;  key=val  ";
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(descriptor);
+        TestRegionProvider testProvider = (TestRegionProvider) provider;
+        assertEquals("us-west-2", testProvider.getConfig().get("region"));
+        assertEquals("val", testProvider.getConfig().get("key"));
+    }
+
+    @Test
+    public void testGetInstanceWithEmptyParams() {
+        String descriptor = TEST_PROVIDER_CLASS + "?";
+        ConfigurableRegionProvider provider = ConfigurableRegionProvider.getInstance(descriptor);
+        assertNotNull(provider);
+        TestRegionProvider testProvider = (TestRegionProvider) provider;
+        assertTrue(testProvider.getConfig().isEmpty());
+    }
+
+    @Test
+    public void testGetInstanceNullDescriptor() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConfigurableRegionProvider.getInstance(null));
+    }
+
+    @Test
+    public void testGetInstanceBlankDescriptor() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConfigurableRegionProvider.getInstance("   "));
+    }
+
+    @Test
+    public void testGetInstanceNonExistentClass() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConfigurableRegionProvider.getInstance("com.nonexistent.FakeProvider"));
+    }
+
+    @Test
+    public void testGetInstanceClassNotImplementingInterface() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ConfigurableRegionProvider.getInstance(NotARegionProvider.class.getName()));
+    }
+}

--- a/src/test/java/software/amazon/msk/auth/iam/internals/region/NotARegionProvider.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/region/NotARegionProvider.java
@@ -1,0 +1,11 @@
+package software.amazon.msk.auth.iam.internals.region;
+
+import java.util.Map;
+
+/**
+ * A class that does NOT implement ConfigurableRegionProvider, used for negative tests.
+ */
+public class NotARegionProvider {
+    public NotARegionProvider(Map<String, String> config) {
+    }
+}

--- a/src/test/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProviderTest.java
@@ -1,0 +1,71 @@
+package software.amazon.msk.auth.iam.internals.region;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Route53RegionProviderTest {
+
+    @Test
+    public void testConstructorWithHost() {
+        Map<String, String> config = new HashMap<>();
+        config.put("host", "region.my-cluster.example.com");
+        Route53RegionProvider provider = new Route53RegionProvider(config);
+        assertNotNull(provider);
+    }
+
+    @Test
+    public void testConstructorWithEmptyConfig() {
+        Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
+        assertNotNull(provider);
+    }
+
+    @Test
+    public void testConstructorWithNullConfig() {
+        Route53RegionProvider provider = new Route53RegionProvider(null);
+        assertNotNull(provider);
+    }
+
+    @Test
+    public void testGetRegionNoHostConfiguredAndNullParam() {
+        Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
+        assertThrows(SdkClientException.class, () -> provider.getRegion(null));
+    }
+
+    @Test
+    public void testGetRegionNoHostConfiguredAndBlankParam() {
+        Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
+        assertThrows(SdkClientException.class, () -> provider.getRegion("  "));
+    }
+
+    @Test
+    public void testGetRegionNoArgDelegatesToGetRegionWithNull() {
+        Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
+        // No host configured, getRegion() calls getRegion(null) which should fail
+        assertThrows(SdkClientException.class, () -> provider.getRegion());
+    }
+
+    @Test
+    public void testGetRegionDnsLookupFailsWithConfiguredHost() {
+        Map<String, String> config = new HashMap<>();
+        config.put("host", "nonexistent.invalid.host.example.invalid");
+        Route53RegionProvider provider = new Route53RegionProvider(config);
+        // DNS lookup for a non-existent host should throw
+        assertThrows(SdkClientException.class, () -> provider.getRegion("ignored"));
+    }
+
+    @Test
+    public void testGetRegionDnsLookupFailsWithDerivedHost() {
+        Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
+        // Will try to resolve "region.nonexistent.invalid" which should fail
+        assertThrows(SdkClientException.class,
+                () -> provider.getRegion("nonexistent.invalid"));
+    }
+}

--- a/src/test/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProviderTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/region/Route53RegionProviderTest.java
@@ -1,14 +1,21 @@
 package software.amazon.msk.auth.iam.internals.region;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Route53RegionProviderTest {
@@ -48,7 +55,6 @@ public class Route53RegionProviderTest {
     @Test
     public void testGetRegionNoArgDelegatesToGetRegionWithNull() {
         Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
-        // No host configured, getRegion() calls getRegion(null) which should fail
         assertThrows(SdkClientException.class, () -> provider.getRegion());
     }
 
@@ -57,15 +63,146 @@ public class Route53RegionProviderTest {
         Map<String, String> config = new HashMap<>();
         config.put("host", "nonexistent.invalid.host.example.invalid");
         Route53RegionProvider provider = new Route53RegionProvider(config);
-        // DNS lookup for a non-existent host should throw
         assertThrows(SdkClientException.class, () -> provider.getRegion("ignored"));
     }
 
     @Test
     public void testGetRegionDnsLookupFailsWithDerivedHost() {
         Route53RegionProvider provider = new Route53RegionProvider(Collections.emptyMap());
-        // Will try to resolve "region.nonexistent.invalid" which should fail
         assertThrows(SdkClientException.class,
                 () -> provider.getRegion("nonexistent.invalid"));
+    }
+
+    @Test
+    public void testRefreshSecondsZeroDisablesCaching() {
+        Map<String, String> config = new HashMap<>();
+        config.put("refresh.seconds", "0");
+        config.put("host", "test.example.com");
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        Clock clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneId.of("UTC"));
+
+        Route53RegionProvider provider = new Route53RegionProvider(config, clock) {
+            @Override
+            String resolveTxtRecord(String lookupHost) {
+                callCount.incrementAndGet();
+                return "us-east-1";
+            }
+        };
+
+        provider.getRegion("any");
+        provider.getRegion("any");
+        assertEquals(2, callCount.get(), "With caching disabled, every call should resolve DNS");
+    }
+
+    @Test
+    public void testRefreshSecondsInvalidValueUsesDefault() {
+        Map<String, String> config = new HashMap<>();
+        config.put("refresh.seconds", "not-a-number");
+        config.put("host", "test.example.com");
+        Route53RegionProvider provider = new Route53RegionProvider(config);
+        assertNotNull(provider);
+    }
+
+    @Test
+    public void testCacheReturnsCachedValueBeforeExpiry() {
+        Instant now = Instant.parse("2025-01-01T00:00:00Z");
+        Clock fixedClock = Clock.fixed(now, ZoneId.of("UTC"));
+
+        Map<String, String> config = new HashMap<>();
+        config.put("host", "test.example.com");
+        config.put("refresh.seconds", "60");
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        Route53RegionProvider provider = new Route53RegionProvider(config, fixedClock) {
+            @Override
+            String resolveTxtRecord(String lookupHost) {
+                callCount.incrementAndGet();
+                return "us-east-1";
+            }
+        };
+
+        Region first = provider.getRegion("any");
+        Region second = provider.getRegion("any");
+
+        assertEquals(Region.US_EAST_1, first);
+        assertEquals(Region.US_EAST_1, second);
+        assertEquals(1, callCount.get(), "DNS should only be called once due to caching");
+    }
+
+    @Test
+    public void testCacheRefreshesAfterExpiry() {
+        Instant t0 = Instant.parse("2025-01-01T00:00:00Z");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("host", "test.example.com");
+        config.put("refresh.seconds", "60");
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        AtomicReference<Clock> clockRef = new AtomicReference<>(
+                Clock.fixed(t0, ZoneId.of("UTC")));
+
+        // We need a mutable clock, so we use a wrapper
+        Route53RegionProvider provider = new Route53RegionProvider(config,
+                Clock.fixed(t0, ZoneId.of("UTC"))) {
+            @Override
+            String resolveTxtRecord(String lookupHost) {
+                callCount.incrementAndGet();
+                return "eu-west-1";
+            }
+        };
+
+        Region first = provider.getRegion("any");
+        assertEquals(Region.EU_WEST_1, first);
+        assertEquals(1, callCount.get());
+
+        // Same clock, should still be cached
+        Region second = provider.getRegion("any");
+        assertEquals(Region.EU_WEST_1, second);
+        assertEquals(1, callCount.get());
+
+        // Create a new provider with advanced clock to test expiry
+        Instant t1 = t0.plus(Duration.ofSeconds(120));
+        Route53RegionProvider provider2 = new Route53RegionProvider(config,
+                Clock.fixed(t1, ZoneId.of("UTC"))) {
+            @Override
+            String resolveTxtRecord(String lookupHost) {
+                callCount.incrementAndGet();
+                return "eu-west-1";
+            }
+        };
+
+        // New provider, empty cache, should call DNS
+        Region third = provider2.getRegion("any");
+        assertEquals(Region.EU_WEST_1, third);
+        assertEquals(2, callCount.get(), "DNS should be called again with a fresh provider");
+    }
+
+    @Test
+    public void testCustomRefreshSeconds() {
+        Instant now = Instant.parse("2025-01-01T00:00:00Z");
+        Clock fixedClock = Clock.fixed(now, ZoneId.of("UTC"));
+
+        Map<String, String> config = new HashMap<>();
+        config.put("host", "test.example.com");
+        config.put("refresh.seconds", "3600");
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        Route53RegionProvider provider = new Route53RegionProvider(config, fixedClock) {
+            @Override
+            String resolveTxtRecord(String lookupHost) {
+                callCount.incrementAndGet();
+                return "ap-southeast-1";
+            }
+        };
+
+        Region result = provider.getRegion("any");
+        assertEquals(Region.AP_SOUTHEAST_1, result);
+
+        // Multiple calls should all be cached
+        for (int i = 0; i < 10; i++) {
+            provider.getRegion("any");
+        }
+        assertEquals(1, callCount.get(), "All calls should use cache with 3600s TTL");
     }
 }

--- a/src/test/java/software/amazon/msk/auth/iam/internals/region/TestRegionProvider.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/region/TestRegionProvider.java
@@ -1,0 +1,31 @@
+package software.amazon.msk.auth.iam.internals.region;
+
+import java.util.Map;
+
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * A simple test implementation of {@link ConfigurableRegionProvider} used in unit tests.
+ */
+public class TestRegionProvider implements ConfigurableRegionProvider {
+    private final Map<String, String> config;
+
+    public TestRegionProvider(Map<String, String> config) {
+        this.config = config;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    @Override
+    public Region getRegion(String host) {
+        String regionId = config.get("region");
+        return regionId != null ? Region.of(regionId) : Region.US_EAST_1;
+    }
+
+    @Override
+    public Region getRegion() {
+        return getRegion(null);
+    }
+}

--- a/src/test/java/software/amazon/msk/auth/iam/internals/utils/RegionUtilsTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/utils/RegionUtilsTest.java
@@ -1,0 +1,100 @@
+package software.amazon.msk.auth.iam.internals.utils;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.msk.auth.iam.internals.region.ConfigurableRegionProvider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RegionUtilsTest {
+
+    private static final String HOST_WITH_REGION = "b-3.unit-test.abcdef.kafka.us-west-2.amazonaws.com";
+    private static final String HOST_NO_REGION = "abcd.efgh.com";
+
+    @Test
+    public void testExtractRegionFromHostWithRegionInHost() {
+        Region region = RegionUtils.extractRegionFromHost(HOST_WITH_REGION);
+        assertEquals(Region.US_WEST_2, region);
+    }
+
+    @Test
+    public void testExtractRegionFromHostWithRegionInHostIgnoresProvider() {
+        ConfigurableRegionProvider mockProvider = mock(ConfigurableRegionProvider.class);
+        Region region = RegionUtils.extractRegionFromHost(HOST_WITH_REGION, mockProvider);
+        assertEquals(Region.US_WEST_2, region);
+        verify(mockProvider, never()).getRegion(Mockito.anyString());
+    }
+
+    @Test
+    public void testExtractRegionFromHostCustomProviderReturnsRegion() {
+        ConfigurableRegionProvider mockProvider = mock(ConfigurableRegionProvider.class);
+        when(mockProvider.getRegion(HOST_NO_REGION)).thenReturn(Region.EU_WEST_1);
+
+        Region region = RegionUtils.extractRegionFromHost(HOST_NO_REGION, mockProvider);
+        assertEquals(Region.EU_WEST_1, region);
+        verify(mockProvider).getRegion(HOST_NO_REGION);
+    }
+
+    @Test
+    public void testExtractRegionFromHostCustomProviderReturnsNullFallsBackToDefault() {
+        ConfigurableRegionProvider mockProvider = mock(ConfigurableRegionProvider.class);
+        when(mockProvider.getRegion(HOST_NO_REGION)).thenReturn(null);
+
+        try (MockedStatic<DefaultAwsRegionProviderChain> mockStatic =
+                     Mockito.mockStatic(DefaultAwsRegionProviderChain.class)) {
+            DefaultAwsRegionProviderChain mockChain = mock(DefaultAwsRegionProviderChain.class);
+            when(mockChain.getRegion()).thenReturn(Region.AP_NORTHEAST_1);
+
+            DefaultAwsRegionProviderChain.Builder mockBuilder = mock(DefaultAwsRegionProviderChain.Builder.class);
+            when(mockBuilder.build()).thenReturn(mockChain);
+            mockStatic.when(DefaultAwsRegionProviderChain::builder).thenReturn(mockBuilder);
+
+            Region region = RegionUtils.extractRegionFromHost(HOST_NO_REGION, mockProvider);
+            assertEquals(Region.AP_NORTHEAST_1, region);
+        }
+    }
+
+    @Test
+    public void testExtractRegionFromHostCustomProviderThrowsFallsBackToDefault() {
+        ConfigurableRegionProvider mockProvider = mock(ConfigurableRegionProvider.class);
+        when(mockProvider.getRegion(HOST_NO_REGION))
+                .thenThrow(SdkClientException.create("DNS lookup failed"));
+
+        try (MockedStatic<DefaultAwsRegionProviderChain> mockStatic =
+                     Mockito.mockStatic(DefaultAwsRegionProviderChain.class)) {
+            DefaultAwsRegionProviderChain mockChain = mock(DefaultAwsRegionProviderChain.class);
+            when(mockChain.getRegion()).thenReturn(Region.US_EAST_1);
+
+            DefaultAwsRegionProviderChain.Builder mockBuilder = mock(DefaultAwsRegionProviderChain.Builder.class);
+            when(mockBuilder.build()).thenReturn(mockChain);
+            mockStatic.when(DefaultAwsRegionProviderChain::builder).thenReturn(mockBuilder);
+
+            Region region = RegionUtils.extractRegionFromHost(HOST_NO_REGION, mockProvider);
+            assertEquals(Region.US_EAST_1, region);
+        }
+    }
+
+    @Test
+    public void testExtractRegionFromHostNullProviderFallsBackToDefault() {
+        try (MockedStatic<DefaultAwsRegionProviderChain> mockStatic =
+                     Mockito.mockStatic(DefaultAwsRegionProviderChain.class)) {
+            DefaultAwsRegionProviderChain mockChain = mock(DefaultAwsRegionProviderChain.class);
+            when(mockChain.getRegion()).thenReturn(Region.SA_EAST_1);
+
+            DefaultAwsRegionProviderChain.Builder mockBuilder = mock(DefaultAwsRegionProviderChain.Builder.class);
+            when(mockBuilder.build()).thenReturn(mockChain);
+            mockStatic.when(DefaultAwsRegionProviderChain::builder).thenReturn(mockBuilder);
+
+            Region region = RegionUtils.extractRegionFromHost(HOST_NO_REGION, null);
+            assertEquals(Region.SA_EAST_1, region);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #237 

*Description of changes:*

This PR introduces a new JAAS config parameter `awsMskRegionProvider` that allows users to plug in a custom region resolution strategy. This is useful when the MSK broker hostname does not contain the AWS region (e.g. behind a DNS alias or custom domain) and the default `DefaultAwsRegionProviderChain` is not suitable.

## What Changed

### New Classes

- **`ConfigurableRegionProvider`** (`internals.region`) — Interface extending `AwsRegionProvider` with:
  - `Region getRegion(String host)` — overloaded method that receives the broker host for context-aware resolution
  - `static getInstance(String descriptor)` — factory that parses a `className?param1=value1;param2=value2` descriptor, extracts params into a `Map<String, String>`, and instantiates the class via its map constructor

- **`Route53RegionProvider`** (`internals.region`) — Built-in implementation that resolves the region by performing a DNS TXT record lookup using JNDI (`com.sun.jndi.dns.DnsContextFactory`). Supports time-based caching.
  - `host` param: explicit hostname for TXT lookup; if omitted, derives it by prefixing the broker host with `region.`
  - `refresh.seconds` param: cache TTL (default 60s, set to 0 to disable)

### Modified Classes

- **`RegionUtils`** — `extractRegionFromHost` now accepts an optional `ConfigurableRegionProvider`. If the provider returns null or throws, a warning is logged and it falls back to `DefaultAwsRegionProviderChain`.
- **`AuthenticationRequestParams`** — New `create` overload accepting a `ConfigurableRegionProvider`, threaded through to `RegionUtils`.
- **`AWSCredentialsCallback`** — New `customRegionProvider` field so the region provider can travel from the callback handler to `IAMSaslClient`.
- **`MSKCredentialProvider`** — Reads `awsMskRegionProvider` from JAAS options, instantiates via `ConfigurableRegionProvider.getInstance()`, and exposes it via `getCustomRegionProvider()`.
- **`IAMClientCallbackHandler`** — Extracts the custom region provider from `MSKCredentialProvider` and sets it on `AWSCredentialsCallback`.
- **`IAMSaslClient`** — Passes the custom region provider from the callback to `AuthenticationRequestParams.create()`.
- **`IAMOAuthBearerLoginCallbackHandler`** — Uses the custom region provider as its `awsRegionProvider` when configured.

### Removed

- **`DynamicAwsRegionProviderChain`** — Had zero references in the codebase; removed as dead code.

### Other

- Version bumped from `2.3.5` to `2.3.6`
- README updated with documentation and release notes
- Existing tests updated for new `RegionUtils` signature
- New test classes added (see below)

## New Tests

- `ConfigurableRegionProviderTest` — descriptor parsing, whitespace handling, error cases
- `Route53RegionProviderTest` — constructor variants, DNS failure handling, cache hit/miss/expiry/disable
- `RegionUtilsTest` — provider success, null return fallback, exception fallback, null provider
- `MSKCredentialProviderTest` — 4 new tests for `awsMskRegionProvider` option handling
- `AuthenticateRequestParamsTest` — 2 new tests for the `ConfigurableRegionProvider` overload

## Usage

### Basic — Route53 TXT record with explicit host

```properties
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider?host=region.my-cluster.example.com;refresh.seconds=60";
```

The provider will look up the TXT record at `region.my-cluster.example.com` and use its value (e.g. `us-east-1`) as the region.

### Route53 TXT record with derived host

```properties
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider";
```

When `host` is omitted, the provider prefixes the broker hostname with `region.` (e.g. broker `kafka.example.com` → TXT lookup on `region.kafka.example.com`).

### Combined with other JAAS options

```properties
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
  awsRoleArn="arn:aws:iam::123456789012:role/msk_client_role" \
  awsRoleSessionName="producer" \
  awsStsRegion="us-west-2" \
  awsMskRegionProvider="software.amazon.msk.auth.iam.internals.region.Route53RegionProvider?host=region.my-cluster.example.com";
```

### Custom implementation

Implement `ConfigurableRegionProvider` with a `Map<String, String>` constructor:

```java
public class MyRegionProvider implements ConfigurableRegionProvider {
    public MyRegionProvider(Map<String, String> config) { /* ... */ }

    @Override
    public Region getRegion() { return getRegion(null); }

    @Override
    public Region getRegion(String host) { return Region.of("eu-west-1"); }
}
```

```properties
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required \
  awsMskRegionProvider="com.example.MyRegionProvider?myParam=myValue";
```

## Fallback Behavior

1. Region is first extracted from the broker hostname (e.g. `kafka.us-west-2.amazonaws.com` → `us-west-2`)
2. If not found and a custom provider is configured, it is called with the broker host
3. If the provider returns null or throws, a warning is logged and `DefaultAwsRegionProviderChain` is used
4. If no custom provider is configured, `DefaultAwsRegionProviderChain` is used directly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
