### PR TITLE
Use Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ plugins {
 }
 
 
-sourceCompatibility = 17
-targetCompatibility = 17
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
@@ -45,7 +45,7 @@ group "software.amazon.msk"
 dependencies {
     compileOnly('org.apache.kafka:kafka-clients:2.8.1')
     // aws sdk imports.
-    implementation(platform('software.amazon.awssdk:bom:2.36.3'))
+    implementation(platform('software.amazon.awssdk:bom:2.40.11'))
     implementation('software.amazon.awssdk:auth')
     implementation('software.amazon.awssdk:sso')
     implementation('software.amazon.awssdk:ssooidc')

--- a/src/main/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProvider.java
+++ b/src/main/java/software/amazon/msk/auth/iam/internals/region/ConfigurableRegionProvider.java
@@ -55,7 +55,7 @@ public interface ConfigurableRegionProvider extends AwsRegionProvider {
      *         the class cannot be instantiated
      */
     static ConfigurableRegionProvider getInstance(String descriptor) {
-        if (descriptor == null || descriptor.isBlank()) {
+        if (descriptor == null || descriptor.trim().isEmpty()) {
             throw new IllegalArgumentException("Region provider descriptor must not be null or blank");
         }
 
@@ -85,9 +85,9 @@ public interface ConfigurableRegionProvider extends AwsRegionProvider {
         }
     }
 
-    private static Map<String, String> parseParams(String queryString) {
+    static Map<String, String> parseParams(String queryString) {
         Map<String, String> params = new LinkedHashMap<>();
-        if (queryString == null || queryString.isBlank()) {
+        if (queryString == null || queryString.trim().isEmpty()) {
             return params;
         }
         for (String pair : queryString.split(";")) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 #Updated on 2025-10-29T16:45:00Z
 platform=java
-version=2.3.6
+version=2.3.7-rc1

--- a/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
+++ b/src/test/java/software/amazon/msk/auth/iam/IAMOAuthBearerLoginCallbackHandlerTest.java
@@ -37,7 +37,8 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.security.scram.ScramCredentialCallback;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
+
 import software.amazon.msk.auth.iam.internals.utils.URIUtils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
+++ b/src/test/java/software/amazon/msk/auth/iam/internals/SignedPayloadValidatorUtils.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
+import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
*Issue #231 and #228

*Description of changes:*
Introduction of Java 17 is not needed to resolve CVEs in Netty 4.1.126 as demonstrated here https://github.com/michalklempa/aws-msk-iam-auth/pull/1/commits and issue #220 is solved solely by bumping the aws-sdk BOM.

Build problems  from issue #112 on original 2.3.4 release can be fixed by using Gradle 7.6.6 and JDK 11 to build the project from that period, this is just undocumented.

After merging #238 some non Java 8 syntax slipped in, this can be easily reverted to Java 8.

In tests, there is still wrong import of
```
import software.amazon.awssdk.http.auth.aws.internal.signer.util.SignerConstant;
```

which is being relocated to new package in aws-sdk upstream.

The aws-sdk shall be bumped to 2.40.11 to address #231 and imports fixes in tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
